### PR TITLE
add comment about com.newrelic.shared

### DIFF
--- a/java/otel-nr-dt/otel-app/src/main/java/com/newrelic/app/Application.java
+++ b/java/otel-nr-dt/otel-app/src/main/java/com/newrelic/app/Application.java
@@ -1,6 +1,8 @@
 package com.newrelic.app;
 
+//note that this dependency is just "a place where you would do your OTel setup"; not an actual dependency on New Relic SDKs.
 import com.newrelic.shared.OpenTelemetryConfig;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 


### PR DESCRIPTION
Just adding this as an idea - at first I was not clear why the oTel example has a dependency on NR, until I looked deeper into the NR code. Possible that field team members may not be able to dig into the code quickly on this, while in a demo to customers. Hope is to prevent any customer devs from thinking that any NR-specific code is required, when instrumenting oTel and planning to ship to NR.