### PR TITLE
Update java logs-in-context-log4j2 example to run the collector as an agent or sidecar

### DIFF
--- a/java/agent-nr-config/application/build.gradle
+++ b/java/agent-nr-config/application/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java-library'
-    id 'org.springframework.boot' version '2.4.3'
+    id 'org.springframework.boot' version '2.4.6'
     id 'io.spring.dependency-management' version '1.0.10.RELEASE'
     id 'de.undercouch.download' version '4.1.1'
 }

--- a/java/logs-in-context-log4j2/README.md
+++ b/java/logs-in-context-log4j2/README.md
@@ -6,48 +6,44 @@ This project contains a Java application configured to use [Log4j2](https://logg
 
 The [log4j2.xml](./src/main/resources/log4j2.xml) configures the application to log out to the console with a [JSON Template Layout](https://logging.apache.org/log4j/2.x/manual/json-template-layout.html) defined in [Log4j2EventLayout.json](./src/main/resources/Log4j2EventLayout.json). The layout follows the [New Relic structured logging conventions](https://github.com/newrelic/newrelic-exporter-specs/tree/master/logging).
 
-The application uses the [OpenTelemetry Log4j2 Integration](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/log4j/log4j-2.13.2/library) to inject trace context to Log4j2 [thread context](https://logging.apache.org/log4j/2.x/manual/thread-context.html). 
+The application uses the [OpenTelemetry Log4j2 Integration](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/log4j/log4j-2.13.2/library) to inject trace context to Log4j2 [thread context](https://logging.apache.org/log4j/2.x/manual/thread-context.html).
 
 The result is JSON structured logs, with one JSON object per line, which have the `span.id` and `trace.id` from OpenTelemetry included:
-```json
-{"timestamp":"2021-05-19T15:51:16.063-05:00","thread.name":"http-nio-8080-exec-1","log.level":"INFO","logger.name":"com.newrelic.app.Controller","message":"A sample log message!","trace.id":"6aae93314fe034149cd85f07eac24bc5","span.id":"f1be31bc6e4471d8","service.name":"logs-in-context"}
-```
-Or pretty printed:
+
 ```json
 {
-	"timestamp": "2021-05-19T15:51:16.063-05:00",
-	"thread.name": "http-nio-8080-exec-1",
-	"log.level": "INFO",
-	"logger.name": "com.newrelic.app.Controller",
-	"message": "A sample log message!",
-	"trace.id": "6aae93314fe034149cd85f07eac24bc5",
-	"span.id": "f1be31bc6e4471d8",
-	"service.name": "logs-in-context"
+  "timestamp": "2021-05-19T15:51:16.063-05:00",
+  "thread.name": "http-nio-8080-exec-1",
+  "log.level": "INFO",
+  "logger.name": "com.newrelic.app.Controller",
+  "message": "A sample log message!",
+  "trace.id": "6aae93314fe034149cd85f07eac24bc5",
+  "span.id": "f1be31bc6e4471d8"
 }
 ```
 
 ## Run
 
-The application runs with Docker, and the [docker-compose.yaml](./docker-compose.yaml) is configured to use the [Fluentd logging driver](https://docs.docker.com/config/containers/logging/fluentd/) to forward logs to an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) configured to receive Fluentd logs and forward them to New Relic.
-
-The application leverages the collector defined in [nr-exporter-docker](../../collector/nr-exporter-docker). First run the collector according to the instructions.
+The application runs with Docker, and the [docker-compose.yaml](./docker-compose.yaml) is configured to use the [Fluentd logging driver](https://docs.docker.com/config/containers/logging/fluentd/) to forward logs to an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) running as an agent next to the service configured to receive Fluentd logs and forward them to New Relic.
 
 Next, build the application, and run the application with docker compose:
+
 ```shell
 ./gradlew logs-in-context-log4j2:bootJar
-docker-compose -f logs-in-context-log4j2/docker-compose.yaml build
+
 docker-compose -f logs-in-context-log4j2/docker-compose.yaml up
 ```
 
 Exercise logs in context by calling the `GET /ping`, which generated a log message inside the context of a trace:
+
 ```shell
 curl http://localhost:8080/ping
 ```
 
 You should be able to see a mix of trace and log data flowing through the collector. If you navigate to the distributed traces of the application in [New Relic One](https://one.newrelic.com/), you should be able to find traces related to the call to `GET /ping`, and see the logs in context:
 
-*Trace With Logs*
+_Trace With Logs_
 ![](trace-with-logs.png)
 
-*Trace Logs In Context*
+_Trace Logs In Context_
 ![](trace-logs-in-context.png)

--- a/java/logs-in-context-log4j2/README.md
+++ b/java/logs-in-context-log4j2/README.md
@@ -26,6 +26,10 @@ The result is JSON structured logs, with one JSON object per line, which have th
 
 The application runs with Docker, and the [docker-compose.yaml](./docker-compose.yaml) is configured to use the [Fluentd logging driver](https://docs.docker.com/config/containers/logging/fluentd/) to forward logs to an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) running as an agent next to the service configured to receive Fluentd logs and forward them to New Relic.
 
+Similar example using FluentBit:
+
+![](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/img/app-to-file-logs-fb.png?raw=true)
+
 Next, build the application, and run the application with docker compose:
 
 ```shell

--- a/java/logs-in-context-log4j2/build.gradle
+++ b/java/logs-in-context-log4j2/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java-library'
-    id 'org.springframework.boot' version '2.4.3'
+    id 'org.springframework.boot' version '2.4.6'
     id 'io.spring.dependency-management' version '1.0.10.RELEASE'
 }
 

--- a/java/logs-in-context-log4j2/docker-compose.yaml
+++ b/java/logs-in-context-log4j2/docker-compose.yaml
@@ -3,17 +3,28 @@ services:
   app:
     build: ./
     environment:
-      SERVICE_NAME: "logs-in-context"
-      OTLP_HOST: "http://collector:4317"
+      OTLP_HOST: 'http://collector:4317'
     ports:
-      - "8080:8080"
+      - '8080:8080'
     logging:
       driver: fluentd
       options:
         fluentd-address: localhost:8006
-    networks:
-      - nr-exporter-docker
+    depends_on:
+      - otel-collector
 
-networks:
-  nr-exporter-docker:
-    name: nr-exporter-docker
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.27.0
+    volumes:
+      - ./otel-config.yaml:/otel-config.yaml
+    entrypoint: ['/otelcontribcol']
+    command: ['--config', '/otel-config.yaml']
+    environment:
+      LOG_EXPORTER_LOG_LEVEL: 'DEBUG'
+      NEW_RELIC_API_KEY: '${NEW_RELIC_API_KEY}'
+      SERVICE_NAME: 'logs-in-context'
+    ports:
+      - '4317:4317' # OTLP gRPC receiver
+      - '13133:13133' # health_check
+      - '8006:8006' # Fluentd forward receiver
+      - '8006:8006/udp' # Fluentd forward receiver

--- a/java/logs-in-context-log4j2/otel-config.yaml
+++ b/java/logs-in-context-log4j2/otel-config.yaml
@@ -1,0 +1,32 @@
+extensions:
+  health_check: {}
+receivers:
+  otlp:
+    protocols:
+      grpc:
+  fluentforward:
+    endpoint: 0.0.0.0:8006
+processors:
+  resource:
+    attributes:
+      - key: service.name
+        value: $SERVICE_NAME
+        action: insert
+exporters:
+  logging:
+    logLevel: $LOG_EXPORTER_LOG_LEVEL
+  newrelic:
+    apikey: $NEW_RELIC_API_KEY
+service:
+  extensions: [health_check]
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      exporters: [logging, newrelic]
+    traces:
+      receivers: [otlp]
+      exporters: [logging, newrelic]
+    logs:
+      receivers: [fluentforward]
+      processors: [resource]
+      exporters: [logging, newrelic]

--- a/java/logs-in-context-log4j2/src/main/java/com/newrelic/app/Application.java
+++ b/java/logs-in-context-log4j2/src/main/java/com/newrelic/app/Application.java
@@ -1,6 +1,5 @@
 package com.newrelic.app;
 
-import com.newrelic.shared.OpenTelemetryConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -8,8 +7,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class Application {
 
   public static void main(String[] args) {
-    // Configure OpenTelemetry as early as possible
-    OpenTelemetryConfig.configureGlobal("logs-in-context");
     SpringApplication.run(Application.class, args);
   }
 }

--- a/java/logs-in-context-log4j2/src/main/resources/Log4j2EventLayout.json
+++ b/java/logs-in-context-log4j2/src/main/resources/Log4j2EventLayout.json
@@ -52,6 +52,5 @@
   "span.id": {
     "$resolver": "mdc",
     "key": "span_id"
-  },
-  "service.name": "${env:SERVICE_NAME:-logs-in-context}"
+  }
 }

--- a/java/otel-nr-dt/nr-app/build.gradle
+++ b/java/otel-nr-dt/nr-app/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java-library'
-    id 'org.springframework.boot' version '2.4.3'
+    id 'org.springframework.boot' version '2.4.6'
     id 'io.spring.dependency-management' version '1.0.10.RELEASE'
     id 'de.undercouch.download' version '4.1.1'
 }

--- a/java/otel-nr-dt/otel-app/build.gradle
+++ b/java/otel-nr-dt/otel-app/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java-library'
-    id 'org.springframework.boot' version '2.4.3'
+    id 'org.springframework.boot' version '2.4.6'
     id 'io.spring.dependency-management' version '1.0.10.RELEASE'
     id 'de.undercouch.download' version '4.1.1'
 }

--- a/java/sdk-nr-config/build.gradle
+++ b/java/sdk-nr-config/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java-library'
-    id 'org.springframework.boot' version '2.4.3'
+    id 'org.springframework.boot' version '2.4.6'
     id 'io.spring.dependency-management' version '1.0.10.RELEASE'
 }
 


### PR DESCRIPTION
Added the otel-collector to the docker-compose file for the logs-in-context-log4j2 example and added a resource processor that inserts the service.name resource attribute for the logs. For this example in particular the otel-collector is running next to the service as an agent or sidecar. 