### PR TITLE
Add OTel SDK pipeline example for dotnet.

### DIFF
--- a/dotnet/logs-in-context/LogBootstrapper.cs
+++ b/dotnet/logs-in-context/LogBootstrapper.cs
@@ -1,0 +1,110 @@
+using System;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Serilog;
+using OpenTelemetry.Logs;
+using OpenTelemetry;
+using OpenTelemetry.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Trace;
+
+namespace logs_in_context
+{
+    public static class LogBootstrapper
+    {
+        private static LoggingScenario _loggingScenario;
+        private static ResourceBuilder _resourceBuilder;
+
+        static LogBootstrapper()
+        {
+            var scenarioFromEnvironment = System.Environment.GetEnvironmentVariable("LOGGING_SCENARIO");
+            if (scenarioFromEnvironment != null && Enum.TryParse<LoggingScenario>(scenarioFromEnvironment, true, out var loggingScenario))
+            {
+                _loggingScenario = loggingScenario;
+            }
+            else
+            {
+                _loggingScenario = LoggingScenario.Unspecified;
+            }
+
+            _resourceBuilder = ResourceBuilder.CreateDefault().AddService(GetEnvironmentVariableValueOrNull("SERVICE_NAME"));
+        }
+
+        static public void ConfigureGlobalLoggerForExample()
+        {
+            switch (_loggingScenario)
+            {
+                case LoggingScenario.Unspecified:
+                case LoggingScenario.Serilog:
+                    Log.Logger = new LoggerConfiguration()
+                        .Enrich.FromLogContext()
+                        .Enrich.With<OTelEnricher>()
+                        .WriteTo.Console(new OTelFormatter())
+                        .CreateLogger();
+                    break;
+            }
+        }
+
+        static public IHostBuilder ConfigureAspNetCoreLoggingForExample(this IHostBuilder hostBuilder)
+        {
+            switch (_loggingScenario)
+            {
+                case LoggingScenario.Unspecified:
+                case LoggingScenario.Serilog:
+                    return hostBuilder.UseSerilog();
+                case LoggingScenario.OTelSdk:
+                    return hostBuilder.ConfigureLogging((context, builder) =>
+                        {
+                            builder.ClearProviders();
+
+                            builder.AddOpenTelemetry(options =>
+                                {
+                                    options.SetResourceBuilder(_resourceBuilder);
+                                    options.IncludeScopes = true;
+                                    options.ParseStateValues = true;
+                                    options.IncludeFormattedMessage = true;
+                                    options.AddProcessor(new BatchLogRecordExportProcessor(new OTelLogExporter()));
+                                });
+                        });
+            }
+
+            return hostBuilder;
+        }
+
+        public static IServiceCollection ConfigureTracingForExample(this IServiceCollection services)
+        {
+            // This example uses an insecure gRPC service. In a production system you should use a secure service instead.
+            // See: https://docs.microsoft.com/aspnet/core/grpc/troubleshoot#call-insecure-grpc-services-with-net-core-client
+            AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+
+            return services.AddOpenTelemetryTracing(
+                (builder) => builder
+                    .SetResourceBuilder(_resourceBuilder)
+                    .AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddOtlpExporter(o =>
+                        {
+                            var collectorUrlString = GetEnvironmentVariableValueOrNull("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "OTEL_EXPORTER_OTLP_ENDPOINT");
+                            if (collectorUrlString != null)
+                            {
+                                o.Endpoint = new Uri("http://otel-collector:4317");
+                            }
+                        })
+                    );
+        }
+
+        private static string GetEnvironmentVariableValueOrNull(params string[] environmentVariableNames)
+        {
+            foreach (var variable in environmentVariableNames)
+            {
+                var valueFromEnvironment = System.Environment.GetEnvironmentVariable(variable);
+                if (valueFromEnvironment != null)
+                {
+                    return valueFromEnvironment;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/dotnet/logs-in-context/LoggingScenario.cs
+++ b/dotnet/logs-in-context/LoggingScenario.cs
@@ -1,0 +1,9 @@
+namespace logs_in_context
+{
+    public enum LoggingScenario
+    {
+        Unspecified = 0,
+        Serilog,
+        OTelSdk
+    }
+}

--- a/dotnet/logs-in-context/OTelLogExporter.cs
+++ b/dotnet/logs-in-context/OTelLogExporter.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Text;
+using System.Text.Json;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+
+internal class OTelLogExporter : BaseExporter<LogRecord>
+{
+    private readonly string name;
+
+    public OTelLogExporter(string name = "OtelLogExporter")
+    {
+        this.name = name;
+    }
+
+    public override ExportResult Export(in Batch<LogRecord> batch)
+    {
+        // SuppressInstrumentationScope should be used to prevent exporter
+        // code from generating telemetry and causing live-loop.
+        using var scope = SuppressInstrumentationScope.Begin();
+
+        foreach (var record in batch)
+        {
+            var sb = new StringBuilder();
+
+            sb.Append($"\"timestamp\":\"{record.Timestamp.ToString("o")}\",");
+
+            sb.Append($"\"log.level\":\"{record.LogLevel.ToString()}\",");
+
+            if (record.FormattedMessage != null)
+            {
+                sb.Append($"\"message\":{JsonSerializer.Serialize(record.FormattedMessage)},");
+            }
+
+            if (record.TraceId != default)
+            {
+                sb.Append($"\"trace.id\":{JsonSerializer.Serialize(record.TraceId.ToString())},");
+            }
+
+            if (record.SpanId != default)
+            {
+                sb.Append($"\"span.id\":{JsonSerializer.Serialize(record.SpanId.ToString())},");
+            }
+
+            if (record.Exception != null)
+            {
+                sb.Append($"\"error.class\":{JsonSerializer.Serialize(record.Exception.GetType().FullName)},");
+                if (!string.IsNullOrWhiteSpace(record.Exception.Message))
+                {
+                    sb.Append($"\"error.message\":{JsonSerializer.Serialize(record.Exception.Message)},");
+                }
+                if (!string.IsNullOrWhiteSpace(record.Exception.StackTrace))
+                {
+                    sb.Append($"\"error.stack\":{JsonSerializer.Serialize(record.Exception.StackTrace)},");
+                }
+            }
+
+            record.ForEachScope(ProcessScope, sb);
+
+            void ProcessScope(LogRecordScope scope, StringBuilder builder)
+            {
+                foreach (var scopeItem in scope)
+                {
+                    builder.Append($"{JsonSerializer.Serialize(scopeItem.Key)}:{JsonSerializer.Serialize(scopeItem.Value)},");
+                }
+            }
+
+            // We are not including the resource attributes on this console exporter because the fluent forward receiver in the
+            // collector will not construct a resource from these log message. A resource processor in the collector is still
+            // necessary to add resource attributes.
+
+            Console.WriteLine($"{{{sb.ToString(0, sb.Length - 1)}}}");
+        }
+
+        return ExportResult.Success;
+    }
+}

--- a/dotnet/logs-in-context/Program.cs
+++ b/dotnet/logs-in-context/Program.cs
@@ -1,12 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using Serilog;
 
 namespace logs_in_context
 {
@@ -14,18 +7,14 @@ namespace logs_in_context
     {
         public static void Main(string[] args)
         {
-            Log.Logger = new LoggerConfiguration()
-                .Enrich.FromLogContext()
-                .Enrich.With<OTelEnricher>()
-                .WriteTo.Console(new OTelFormatter())
-                .CreateLogger();
+            LogBootstrapper.ConfigureGlobalLoggerForExample();
 
             CreateHostBuilder(args).Build().Run();
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
-                .UseSerilog()
+                .ConfigureAspNetCoreLoggingForExample()
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();

--- a/dotnet/logs-in-context/Startup.cs
+++ b/dotnet/logs-in-context/Startup.cs
@@ -1,18 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.HttpsPolicy;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
-using OpenTelemetry.Resources;
-using OpenTelemetry.Trace;
 
 namespace logs_in_context
 {
@@ -28,24 +19,8 @@ namespace logs_in_context
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            // This example uses an insecure gRPC service. In a production system you should use a secure service instead.
-            // See: https://docs.microsoft.com/aspnet/core/grpc/troubleshoot#call-insecure-grpc-services-with-net-core-client
-            AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+            services.ConfigureTracingForExample();
 
-            services.AddOpenTelemetryTracing(
-                (builder) => builder
-                    .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(GetEnvironmentVariableValueOrNull("SERVICE_NAME")))
-                    .AddAspNetCoreInstrumentation()
-                    .AddHttpClientInstrumentation()
-                    .AddOtlpExporter(o =>
-                        {
-                            var collectorUrlString = GetEnvironmentVariableValueOrNull("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "OTEL_EXPORTER_OTLP_ENDPOINT");
-                            if (collectorUrlString != null)
-                            {
-                                o.Endpoint = new Uri("http://otel-collector:4317");
-                            }
-                        })
-                    );
             services.AddControllers();
             services.AddSwaggerGen(c =>
             {
@@ -73,20 +48,6 @@ namespace logs_in_context
             {
                 endpoints.MapControllers();
             });
-        }
-
-        private static string GetEnvironmentVariableValueOrNull(params string[] environmentVariableNames)
-        {
-            foreach (var variable in environmentVariableNames)
-            {
-                var valueFromEnvironment = System.Environment.GetEnvironmentVariable(variable);
-                if (valueFromEnvironment != null)
-                {
-                    return valueFromEnvironment;
-                }
-            }
-
-            return null;
         }
     }
 }

--- a/dotnet/logs-in-context/docker-compose.yaml
+++ b/dotnet/logs-in-context/docker-compose.yaml
@@ -3,6 +3,7 @@ services:
   app:
     build: ./
     environment:
+      LOGGING_SCENARIO: ${LOGGING_SCENARIO}
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4317"
       SERVICE_NAME: "logs-in-context-example"
     ports:


### PR DESCRIPTION
Adds a logs in context example where log messages recorded using Microsoft.Extensions.Logging are sent through the OTel SDK to add contextual information and export the log messages.