### PR TITLE
Fix logs-in-context-log4j2 to remove resource processor.

### DIFF
--- a/java/logs-in-context-log4j2/otel-config.yaml
+++ b/java/logs-in-context-log4j2/otel-config.yaml
@@ -24,5 +24,4 @@ service:
       exporters: [logging, otlp]
     logs:
       receivers: [fluentforward]
-      processors: [resource]
       exporters: [logging, otlp]


### PR DESCRIPTION
#65 removed this resource processor but it was not fully removed from the config. This causes the collector to fail to start. cc: @jack-berg 