### PR TITLE
Added cumulative to delta processor

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -4,6 +4,8 @@
 
 This example demonstrates how to run the OpenTelemetry Collector configured to export to New Relic with the [OTLP gRPC exporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlpexporter) via docker. See [documentation](https://docs.newrelic.com/docs/integrations/open-source-telemetry-integrations/opentelemetry/introduction-opentelemetry-new-relic/#how-it-works) for more information about New Relic OTLP support.
 
+This collector is also using the [cumulativetodelta processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/cumulativetodeltaprocessor), which handles converting any monotonic, cumulative sums to monotonic, delta sums.  This is important, as [New Relic does not support monotonic, cumulative sums as Counters](https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-metrics).  
+
 The `docker-compose.yaml` file configures the collector via `otel-config.yaml`.
 
 ## Run

--- a/collector/docker-compose.yaml
+++ b/collector/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   collector:
-    image: otel/opentelemetry-collector-contrib:0.49.0
+    image: otel/opentelemetry-collector-contrib:0.50.0
     volumes:
     - ./otel-config.yaml:/otel-config.yaml
     command: ["/otelcol-contrib", "--config=/otel-config.yaml", "${OTELCOL_ARGS}"]

--- a/collector/otel-config.yaml
+++ b/collector/otel-config.yaml
@@ -6,6 +6,9 @@ receivers:
       grpc:
   fluentforward:
     endpoint: 0.0.0.0:8006
+processors:
+  # Will convert all monotonic, cumulative sums to monotonic, delta sums
+  cumulativetodelta:
 exporters:
   logging:
     logLevel: $LOG_EXPORTER_LOG_LEVEL
@@ -18,6 +21,7 @@ service:
   pipelines:
     metrics:
       receivers: [otlp]
+      processors: [cumulativetodelta]
       exporters: [logging, otlp]
     traces:
       receivers: [otlp]


### PR DESCRIPTION
Updates the collector example to use the cumulativetodelta processor.  Update to collector 0.50.0 was necessary to get the latest version of the cumulativetodelta processor.

Fixes #122