### PR TITLE
Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,17 @@
+# Global codeowners
 * @newrelic/opentelemetry-community
+
+getting-started-guides/             @reese-lee
+getting-started-guides/dotnet/      @alanwest
+getting-started-guides/go/          @utr1903
+getting-started-guides/java/        @jack-berg
+getting-started-guides/javascript   @matewilk
+getting-started-guides/python/      @pnvnd
+getting-started-guides/ruby/        @kaylareopelle
+
+other-examples/collector/   @jcountsNR
+other-examples/dotnet/      @alanwest
+other-examples/java/        @jack-berg
+# TODO: find serverless codeowner
+other-examples/serverless/
+


### PR DESCRIPTION
This repo has quite a bit of content across many languages and technologies. In order to avoid bit rot, we need to have people who understand the different technologies around for code reviews. Ideally, those folks could also occasionally perform maintenance on the examples, updating any dependencies to the latest version.

I went through and added the folks who contributed the various examples as codeowners. Please accept this invitation 🙂. Of course there's no obligation to be a codeowner. If you prefer to not be included, please indicate with a comment on the PR, and consider suggesting someone else as an alternative.

We may delete examples without codeowners since its better to have no example at all than one that is wildly out of date and inaccurate. 