### PR TITLE
added other confluent cloud resources to the sample collector.yaml

### DIFF
--- a/other-examples/collector/confluentcloud/README.md
+++ b/other-examples/collector/confluentcloud/README.md
@@ -17,6 +17,9 @@ To run the example: add in the key files, set the environment variables, and run
 export NEW_RELIC_API_KEY=<your_api_key>
 export NEW_RELIC_OTLP_ENDPOINT=https://otlp.nr-data.net
 export CLUSTER_ID=<your_cluster_id>
+export KSQL_CLUSTER_ID=<your_ksql_cluster_id>
+export CONNECTOR_ID=<your_connector_id>
+export SCHEMA_REGISTRY_ID=<your_schema_registry_id>
 export CLUSTER_API_KEY=<your_cluster_api_key>
 export CLUSTER_API_SECRET=<your_cluster_api_secret>
 export CLUSTER_BOOTSTRAP_SERVER=<your_cluster_bootstrap_server>

--- a/other-examples/collector/confluentcloud/collector.yaml
+++ b/other-examples/collector/confluentcloud/collector.yaml
@@ -30,6 +30,13 @@ receivers:
           params:
             "resource.kafka.id":
               - $CLUSTER_ID
+            "resource.ksql.id":
+              - $KSQL_CLUSTER_ID
+            "resource.connector.id"
+              - $CONNECTOR_ID"
+            "resource.schema_registry.id"
+              - $SCHEMA_REGISTRY_ID
+
 exporters:
   otlp:
     endpoint: $NEW_RELIC_OTLP_ENDPOINT


### PR DESCRIPTION
added the following additional confluent cloud resources to the sample collector.yaml.
```yaml
            "resource.ksql.id":
              - $KSQL_CLUSTER_ID
            "resource.connector.id"
              - $CONNECTOR_ID"
            "resource.schema_registry.id"
              - $SCHEMA_REGISTRY_ID
```