### PR TITLE
chore: Fix issues with confluent cloud example

### DIFF
--- a/other-examples/collector/confluentcloud/README.md
+++ b/other-examples/collector/confluentcloud/README.md
@@ -20,6 +20,8 @@ export CLUSTER_ID=<your_cluster_id>
 export CLUSTER_API_KEY=<your_cluster_api_key>
 export CLUSTER_API_SECRET=<your_cluster_api_secret>
 export CLUSTER_BOOTSTRAP_SERVER=<your_cluster_bootstrap_server>
+export CONFLUENT_API_ID=<your_confluent_api_id>
+export CONFLUENT_API_SECRET=<your_confluent_api_secret>
 
 docker compose up
 ```
@@ -35,5 +37,7 @@ docker compose up
 | **CLUSTER_API_KEY** | Resource API key for your Confluent cluster |[Resource API key docs](https://docs.confluent.io/cloud/current/access-management/authenticate/api-keys/api-keys.html#create-a-resource-api-key) |
 | **CLUSTER_API_SECRET**| Resource API secret key from your Confluent cluster| [Resource API key docs](https://docs.confluent.io/cloud/current/access-management/authenticate/api-keys/api-keys.html#create-a-resource-api-key) |
 | **CLUSTER_BOOTSTRAP_SERVER** | Bootstrap Server for cluster | Available in your cluster settings |
+| **CONFLUENT_API_ID** |ID for Confluent Cloud |[Confluent API key docs](https://docs.confluent.io/cloud/current/access-management/authenticate/api-keys/api-keys.html)|
+| **CONFLUENT_API_SECRET** | API Secret for Confluent Cloud | [Confluent API key docs](https://docs.confluent.io/cloud/current/access-management/authenticate/api-keys/api-keys.html) |
 
 </br>

--- a/other-examples/collector/confluentcloud/collector.yaml
+++ b/other-examples/collector/confluentcloud/collector.yaml
@@ -8,10 +8,14 @@ receivers:
       - topics
       - consumers
     auth:
-      tls:
-        ca_file: ./etc/otelcol/pem/ca.pem
-        cert_file: ./etc/otelcol/pem/cert.pem
-        key_file: ./etc/otelcol/pem/key.pem
+      sasl:
+        username: $CLUSTER_API_KEY
+        password: $CLUSTER_API_SECRET
+        mechanism: PLAIN
+      #tls:
+        #ca_file: ./etc/otelcol/pem/ca.pem
+        #cert_file: ./etc/otelcol/pem/cert.pem
+        #key_file: ./etc/otelcol/pem/key.pem
     collection_interval: 30s
 
 
@@ -30,6 +34,8 @@ receivers:
           params:
             "resource.kafka.id":
               - $CLUSTER_ID
+            # "resource.connector.id"
+            #  - $CONNECTOR_ID
 exporters:
   otlp:
     endpoint: $NEW_RELIC_OTLP_ENDPOINT

--- a/other-examples/collector/confluentcloud/docker-compose.yaml
+++ b/other-examples/collector/confluentcloud/docker-compose.yaml
@@ -7,9 +7,9 @@ services:
     command: --config=/etc/otelcol/config.yaml
     volumes:
       - ./collector.yaml:/etc/otelcol/config.yaml
-      - ./key.pem:/etc/otelcol/pem/key.pem
-      - ./cert.pem:/etc/otelcol/pem/cert.pem
-      - ./ca.pem:/etc/otelcol/pem/ca.pem
+    #  - ./key.pem:/etc/otelcol/pem/key.pem
+    #  - ./cert.pem:/etc/otelcol/pem/cert.pem
+    #  - ./ca.pem:/etc/otelcol/pem/ca.pem
     environment:
       - NEW_RELIC_OTLP_ENDPOINT
       - NEW_RELIC_API_KEY
@@ -17,4 +17,7 @@ services:
       - CLUSTER_API_KEY
       - CLUSTER_API_SECRET
       - CLUSTER_ID
+      - CONFLUENT_API_ID
+      - CONFLUENT_API_SECRET
+    # - CONNECTOR_ID
 


### PR DESCRIPTION
A few errors resolved with this one.

1. Restored the use of the Confluent Cloud API key, and left the pem.key options as commented.
2. Updated the Readme/docker compose to reflect the change
3. Added in a commented Connector ID, showing that both Connectors and Kafka can be monitored with this integration.