### PR TITLE
Relocate to new micrometer-shim location

### DIFF
--- a/java/micrometer-shim/README.md
+++ b/java/micrometer-shim/README.md
@@ -1,0 +1,1 @@
+This page has been relocated to [./other-examples/java/micrometer-shim](../../other-examples/java/micrometer-shim).


### PR DESCRIPTION
The archived [micrometer-registry-newrelic](https://github.com/newrelic/micrometer-registry-newrelic) project contains a link to the micrometer-shim example which has been broken since we relocated that page.

Rather than un-archiving that project, updating the link, and re-archiving it, we can simply add a stub readme at the old location which relocated to the new location.