### PR TITLE
add docs and examples for otelcol and confluent in kubernetes

### DIFF
--- a/other-examples/collector/confluentcloud/kubernetes/README.md
+++ b/other-examples/collector/confluentcloud/kubernetes/README.md
@@ -1,6 +1,6 @@
 # Confluent Cloud OpenTelemetry metrics example Kubernetes setup
 
-This example shows a setup for running a Prometheus OpenTelemetry Collector in a Kubernetes environment to scrape metrics from Confluent Cloud and post them to the New Relic OTLP Collector Endpoint.
+This example shows a setup for running a [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) in a Kubernetes environment to scrape metrics from Confluent Cloud and post them to the New Relic OTLP Collector Endpoint.
 This example also includes config for getting more Kafka metrics about brokers, topics and consumers using the OpenTelemetry Collector's `kafkametrics` receiver.
 
 For more information, please see our [Kafka with Confluent documentation](https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-kafka-confluentcloud/).

--- a/other-examples/collector/confluentcloud/kubernetes/README.md
+++ b/other-examples/collector/confluentcloud/kubernetes/README.md
@@ -1,20 +1,20 @@
-# Confluent Cloud OpenTelemetry metrics example kubernetes setup
+# Confluent Cloud OpenTelemetry metrics example Kubernetes setup
 
-This example shows a setup for running a prometheus OpenTelemetry Collector in a kubernetes environment to scrape metrics from Confluent Cloud and post them to the New Relic OTLP Collector Endpoint.
-This example also includes config for getting more kafka metrics about brokers, topics and consumers using the OpenTelemetry Collector's `kafkametrics` receiver.
+This example shows a setup for running a Prometheus OpenTelemetry Collector in a Kubernetes environment to scrape metrics from Confluent Cloud and post them to the New Relic OTLP Collector Endpoint.
+This example also includes config for getting more Kafka metrics about brokers, topics and consumers using the OpenTelemetry Collector's `kafkametrics` receiver.
 
 For more information, please see our [Kafka with Confluent documentation](https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-kafka-confluentcloud/).
 
 ## Prerequisites
 
-1. You must have a kubernetes cluster running.
-2. You must have [helm](https://helm.sh/docs/intro/quickstart/) installed .
+1. You must have a Kubernetes cluster running.
+2. You must have [Helm](https://helm.sh/docs/intro/quickstart/) installed .
 3. You must have a [Confluent Cloud account](https://www.confluent.io/get-started/) with a cluster running.
 
-## Running the example
+## Running the Helm example
 First, set your variables in the values file `./helm/values.yaml` in this directory. For more information on the individual variables, reference the docs available below.
 
-Once the variables are set, run the following command from the root directory to start the collector in your kubernetes cluster.
+Once the variables are set, run the following command from the root directory to install the collector in your Kubernetes cluster.
 
 ```shell
 cd ./other-examples/collector/kubernetes
@@ -22,15 +22,38 @@ cd ./other-examples/collector/kubernetes
 helm install ./helm
 ```
 
+## Running the raw k8s yaml example
+First, set your variables in the deployment file `./k8s/deployment.yaml` in this directory. For more information on the individual variables, reference the docs available below.
+
+Once the variables are set, run the following command from the root directory to apply the collector to your Kubernetes cluster.
+
+```shell
+cd ./other-examples/collector/kubernetes
+
+kubectl apply -f ./k8s
+```
+
 ## Helm `values.yaml` variable information
 
 | Variable                      | Description                                                               | Docs                                                                                                                                                                                      |
 |-------------------------------|---------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **newrelic.apiKey**           | New Relic Ingest API Key                                                  | [API Key docs](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/)                                                                                                        | 
-| **newrelic.otlpEndpoint**                 | Default US OTLP endpoint is https://otlp.nr-data.net                      | [OTLP endpoint config docs](https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-set-up-your-app/#review-settings) |
+| **newrelic.otlpEndpoint**                 | Default US OTLP Endpoint is https://otlp.nr-data.net                      | [OTLP endpoint config docs](https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-set-up-your-app/#review-settings) |
 | **confluent.apiKey**          | API key for Confluent Cloud, can be created via cli by following the docs | [Confluent API key docs](https://docs.confluent.io/cloud/current/monitoring/metrics-api.html)                                                                                             |
 | **counfluent.apiSecret**      | API secret for Confluent Cloud                                            | [Confluent API key docs](https://docs.confluent.io/cloud/current/monitoring/metrics-api.html)                                                                                             |
 | **confluent.clusterId**       | ID of the cluster from Confluent Cloud                                    | [List cluster ID docs](https://docs.confluent.io/confluent-cli/current/command-reference/kafka/cluster/confluent_kafka_cluster_list.html#description)                                     |
 | **confluent.clusterName**     | Name of the cluster from Confluent Cloud                                  | [List cluster name docs](https://docs.confluent.io/confluent-cli/current/command-reference/kafka/cluster/confluent_kafka_cluster_list.html#description)                                   |
-| **confluent.bootstrapServer** | bootstrap server endpoint for your cluster from Confluent Cloud           | [Describe cluster docs](https://docs.confluent.io/confluent-cli/current/command-reference/kafka/cluster/confluent_kafka_cluster_describe.html#description)                                |
+| **confluent.bootstrapServer** | bootstrap server Endpoint for your cluster from Confluent Cloud           | [Describe cluster docs](https://docs.confluent.io/confluent-cli/current/command-reference/kafka/cluster/confluent_kafka_cluster_describe.html#description)                                |
 
+
+## Raw k8s `env` Variable information
+
+| Variable                    | Description                                                               | Docs |
+|-----------------------------|---------------------------------------------------------------------------| ---- |
+| **NEW_RELIC_API_KEY**       | New Relic Ingest API Key                                                  |[API Key docs](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/) | 
+| **NEW_RELIC_OTLP_ENDPOINT** | Default US OTLP endpoint is https://otlp.nr-data.net                      | [OTLP endpoint config docs](https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-set-up-your-app/#review-settings) |
+| **CONFLUENT_API_KEY**       | API key for Confluent Cloud, can be created via cli by following the docs |[Confluent API key docs](https://docs.confluent.io/cloud/current/monitoring/metrics-api.html)|
+| **CONFLUENT_API_SECRET**    | API secret for Confluent Cloud                                            | [Confluent API key docs](https://docs.confluent.io/cloud/current/monitoring/metrics-api.html) |
+| **CLUSTER_ID**              | ID of the cluster from Confluent Cloud                                    | [List cluster ID docs](https://docs.confluent.io/confluent-cli/current/command-reference/kafka/cluster/confluent_kafka_cluster_list.html#description) |
+| **CLUSTER_NAME**            | Name of the cluster from Confluent Cloud                                  | [List cluster name docs](https://docs.confluent.io/confluent-cli/current/command-reference/kafka/cluster/confluent_kafka_cluster_list.html#description) |
+| **BOOTSTRAP_SERVER**        | bootstrap server Endpoint for your cluster from Confluent Cloud                     | [Describe cluster docs](https://docs.confluent.io/confluent-cli/current/command-reference/kafka/cluster/confluent_kafka_cluster_describe.html#description) |

--- a/other-examples/collector/confluentcloud/kubernetes/README.md
+++ b/other-examples/collector/confluentcloud/kubernetes/README.md
@@ -1,0 +1,36 @@
+# Confluent Cloud OpenTelemetry metrics example kubernetes setup
+
+This example shows a setup for running a prometheus OpenTelemetry Collector in a kubernetes environment to scrape metrics from Confluent Cloud and post them to the New Relic OTLP Collector Endpoint.
+This example also includes config for getting more kafka metrics about brokers, topics and consumers using the OpenTelemetry Collector's `kafkametrics` receiver.
+
+For more information, please see our [Kafka with Confluent documentation](https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-kafka-confluentcloud/).
+
+## Prerequisites
+
+1. You must have a kubernetes cluster running.
+2. You must have [helm](https://helm.sh/docs/intro/quickstart/) installed .
+3. You must have a [Confluent Cloud account](https://www.confluent.io/get-started/) with a cluster running.
+
+## Running the example
+First, set your variables in the values file `./helm/values.yaml` in this directory. For more information on the individual variables, reference the docs available below.
+
+Once the variables are set, run the following command from the root directory to start the collector in your kubernetes cluster.
+
+```shell
+cd ./other-examples/collector/kubernetes
+
+helm install ./helm
+```
+
+## Helm `values.yaml` variable information
+
+| Variable                      | Description                                                               | Docs                                                                                                                                                                                      |
+|-------------------------------|---------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **newrelic.apiKey**           | New Relic Ingest API Key                                                  | [API Key docs](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/)                                                                                                        | 
+| **newrelic.otlpEndpoint**                 | Default US OTLP endpoint is https://otlp.nr-data.net                      | [OTLP endpoint config docs](https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-set-up-your-app/#review-settings) |
+| **confluent.apiKey**          | API key for Confluent Cloud, can be created via cli by following the docs | [Confluent API key docs](https://docs.confluent.io/cloud/current/monitoring/metrics-api.html)                                                                                             |
+| **counfluent.apiSecret**      | API secret for Confluent Cloud                                            | [Confluent API key docs](https://docs.confluent.io/cloud/current/monitoring/metrics-api.html)                                                                                             |
+| **confluent.clusterId**       | ID of the cluster from Confluent Cloud                                    | [List cluster ID docs](https://docs.confluent.io/confluent-cli/current/command-reference/kafka/cluster/confluent_kafka_cluster_list.html#description)                                     |
+| **confluent.clusterName**     | Name of the cluster from Confluent Cloud                                  | [List cluster name docs](https://docs.confluent.io/confluent-cli/current/command-reference/kafka/cluster/confluent_kafka_cluster_list.html#description)                                   |
+| **confluent.bootstrapServer** | bootstrap server endpoint for your cluster from Confluent Cloud           | [Describe cluster docs](https://docs.confluent.io/confluent-cli/current/command-reference/kafka/cluster/confluent_kafka_cluster_describe.html#description)                                |
+

--- a/other-examples/collector/confluentcloud/kubernetes/helm/.helmignore
+++ b/other-examples/collector/confluentcloud/kubernetes/helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/other-examples/collector/confluentcloud/kubernetes/helm/Chart.yaml
+++ b/other-examples/collector/confluentcloud/kubernetes/helm/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: otel-confluent
+description: A Helm chart for open telemetry collector for confluent metrics
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/other-examples/collector/confluentcloud/kubernetes/helm/templates/configmap.yaml
+++ b/other-examples/collector/confluentcloud/kubernetes/helm/templates/configmap.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.name }}-config
+  labels:
+    app.kubernetes.io/name: {{ .Values.name }}-config
+    app.kubernetes.io/part-of: {{ .Values.name }}
+    component: {{ .Values.name }}-config
+data:
+  otel-confluent-config: |
+    receivers:
+      kafkametrics:
+        brokers: 
+          - {{ .Values.confluent.bootstrapServer }}
+        protocol_version: 2.0.0
+        scrapers:
+          - brokers
+          - topics
+          - consumers
+        auth:
+          sasl:
+            username: {{ .Values.confluent.apiKey }}
+            password: {{ .Values.confluent.apiSecret }}
+            mechanism: PLAIN
+          tls:
+            insecure_skip_verify: false
+        collection_interval: 5s
+    
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: "confluent"
+              scrape_interval: 60s # Do not go any lower than this or you'll hit rate limits
+              static_configs:
+                - targets: ["api.telemetry.confluent.cloud"]
+              scheme: https
+              basic_auth:
+                username: {{ .Values.confluent.apiKey }}
+                password: {{ .Values.confluent.apiSecret }}
+              metrics_path: /v2/metrics/cloud/export
+              params:
+                "resource.kafka.id":
+                  - {{ .Values.confluent.clusterId }}
+    exporters:
+      otlp:
+        endpoint: {{ .Values.newrelic.otlpEndpoint }}
+        tls:
+          insecure: false
+        sending_queue:
+          num_consumers: 4
+          queue_size: 100
+        retry_on_failure:
+          enabled: true
+        headers:
+          api-key: {{ .Values.newrelic.apiKey }}
+      logging:
+        loglevel: {{ .Values.logging.level }}
+    processors:
+      batch: # Turn this on if the need arises
+        # send_batch_size: 1000
+        # send_batch_max_size: 1500
+        # timeout: 1s
+      memory_limiter: # doc here: https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/memorylimiterprocessor
+        limit_percentage: 80 # Maximum amount of total memory targeted to be allocated by the process heap
+        spike_limit_percentage: 30 # Maximum spike expected between the measurements of memory usage 
+        check_interval: 5s # Time between measurements of memory usage
+      resource:
+        attributes: # This is necessary since confluent exposes only the cluster id in the metrics
+        - key: kafka.cluster_name
+          value: {{ .Values.confluent.clusterName }}
+          action: upsert
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus, kafkametrics]
+          processors: [memory_limiter, resource, batch]
+          exporters: [logging, otlp]

--- a/other-examples/collector/confluentcloud/kubernetes/helm/templates/deployment.yaml
+++ b/other-examples/collector/confluentcloud/kubernetes/helm/templates/deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.name }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.name }}
+    app.kubernetes.io/part-of: {{ .Values.name }}
+    component: {{ .Values.name }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.name }}
+      component: {{ .Values.name }}
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Values.name }}
+        app.kubernetes.io/part-of: {{ .Values.name }}
+        component: {{ .Values.name }}
+    spec:
+      containers:
+      - command:
+          - "/otelcol-contrib"
+          - "--config=/conf/otel-agent-config.yaml"
+        image: {{ .Values.otel.image }}
+        name: {{ .Values.name }}
+        resources:
+          limits:
+            cpu: "500m"
+            memory: "500Mi"
+          requests:
+            cpu: "100m"
+            memory: "100Mi"
+        ports:
+        - containerPort: 4317 # Default OpenTelemetry receiver port.
+        - containerPort: 8888  # Metrics.
+        volumeMounts:
+        - name: {{ .Values.name }}-config-vol
+          mountPath: /conf
+      volumes:
+        - name: {{ .Values.name }}-config-vol
+          configMap:
+            name: {{ .Values.name }}-config
+            items:
+              - key: {{ .Values.name }}-config
+                path: otel-agent-config.yaml

--- a/other-examples/collector/confluentcloud/kubernetes/helm/values.yaml
+++ b/other-examples/collector/confluentcloud/kubernetes/helm/values.yaml
@@ -1,0 +1,16 @@
+replicaCount: 1
+name: otel-confluent
+logging:
+  level: debug
+otel:
+  image: otel/opentelemetry-collector-contrib:0.92.0
+confluent:
+  apiKey: YOUR_CONFLUENT_API_KEY
+  apiSecret: YOUR_CONFLUENT_API_SECRET
+  clusterId: YOUR_CONFLUENT_CLUSTER_ID
+  clusterName: YOUR_CONFLUENT_CLUSTER_NAME
+  bootstrapServer: YOUR_CONFLUENT_BOOTSTRAP_SERVER
+newrelic:
+  apiKey: YOUR_NEWRELIC_API_KEY
+  otlpEndpoint: otlp.nr-data.net:4318
+

--- a/other-examples/collector/confluentcloud/kubernetes/k8s/configmap.yaml
+++ b/other-examples/collector/confluentcloud/kubernetes/k8s/configmap.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-confluent-config
+  labels:
+    app.kubernetes.io/name: otel-confluent-config
+    app.kubernetes.io/part-of: otel-confluent
+    component: otel-confluent-config
+data:
+  otel-confluent-config: |
+    receivers:
+      kafkametrics:
+        brokers: 
+          - ${BOOTSTRAP_SERVER}
+        protocol_version: 2.0.0
+        scrapers:
+          - brokers
+          - topics
+          - consumers
+        auth:
+          sasl:
+            username: ${CONFLUENT_API_KEY}
+            password: ${CONFLUENT_API_SECRET}
+            mechanism: PLAIN
+          tls:
+            insecure_skip_verify: false
+        collection_interval: 5s
+    
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: "confluent"
+              scrape_interval: 60s # Do not go any lower than this or you'll hit rate limits
+              static_configs:
+                - targets: ["api.telemetry.confluent.cloud"]
+              scheme: https
+              basic_auth:
+                username: ${CONFLUENT_API_KEY}
+                password: ${CONFLUENT_API_SECRET}
+              metrics_path: /v2/metrics/cloud/export
+              params:
+                "resource.kafka.id":
+                  - ${CLUSTER_ID}
+    exporters:
+      otlp:
+        endpoint: ${NEW_RELIC_OTLP_ENDPOINT}
+        tls:
+          insecure: false
+        sending_queue:
+          num_consumers: 4
+          queue_size: 100
+        retry_on_failure:
+          enabled: true
+        headers:
+          api-key: ${NEW_RELIC_API_KEY}
+      logging:
+        loglevel: debug
+    processors:
+      batch: # Turn this on if the need arises
+        # send_batch_size: 1000
+        # send_batch_max_size: 1500
+        # timeout: 1s
+      memory_limiter: # doc here: https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/memorylimiterprocessor
+        limit_percentage: 80 # Maximum amount of total memory targeted to be allocated by the process heap
+        spike_limit_percentage: 30 # Maximum spike expected between the measurements of memory usage 
+        check_interval: 5s # Time between measurements of memory usage
+      resource:
+        attributes: # This is necessary since confluent exposes only the cluster id in the metrics
+        - key: kafka.cluster_name
+          value: ${CLUSTER_NAME}
+          action: upsert
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus, kafkametrics]
+          processors: [memory_limiter, resource, batch]
+          exporters: [logging, otlp]

--- a/other-examples/collector/confluentcloud/kubernetes/k8s/deployment.yaml
+++ b/other-examples/collector/confluentcloud/kubernetes/k8s/deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-confluent
+  labels:
+    app.kubernetes.io/name: otel-confluent
+    app.kubernetes.io/part-of: otel-confluent
+    component: otel-confluent
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: otel-confluent
+      component: otel-confluent
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: otel-confluent
+        app.kubernetes.io/part-of: otel-confluent
+        component: otel-confluent
+    spec:
+      containers:
+      - command:
+          - "/otelcol-contrib"
+          - "--config=/conf/otel-agent-config.yaml"
+        image: otel/opentelemetry-collector-contrib:0.92.0
+        name: otel-confluent
+        resources:
+          limits:
+            cpu: "500m"
+            memory: "500Mi"
+          requests:
+            cpu: "100m"
+            memory: "100Mi"
+        ports:
+        - containerPort: 4317 # Default OpenTelemetry receiver port.
+        - containerPort: 8888  # Metrics.
+        env:
+        - name: NEW_RELIC_API_KEY
+          value: "Your Newrelic API Key"
+        - name: NEW_RELIC_OTLP_ENDPOINT
+          value: "otlp.nr-data.net:4318"
+        - name: CONFLUENT_API_KEY
+          value: "Your Confluent API Key"
+        - name: CONFLUENT_API_SECRET
+          value: "Your Confluent API Secret"
+        - name: CLUSTER_ID
+          value: "Your Confluent cluster id"
+        - name: CLUSTER_NAME
+          value: "Your Confluent cluster name"
+        - name: BOOTSTRAP_SERVER
+          value: "Your Confluent bootstrap server Endpoint"
+        volumeMounts:
+        - name: otel-confluent-config-vol
+          mountPath: /conf
+      volumes:
+        - name: otel-confluent-config-vol
+          configMap:
+            name: otel-confluent-config
+            items:
+              - key: otel-confluent-config
+                path: otel-agent-config.yaml


### PR DESCRIPTION
This PR adds examples for scraping confluent metrics using open telemetry collector in kubernetes