### PR TITLE
Fix python getting started example, normalize env vars

### DIFF
--- a/getting-started-guides/compose.yaml
+++ b/getting-started-guides/compose.yaml
@@ -3,64 +3,84 @@ services:
     build: dotnet
     environment:
       - OTEL_SERVICE_NAME=getting-started-dotnet
+      # No need to set service.instance.id because otel dot net generates random UUID
+      #- OTEL_RESOURCE_ATTRIBUTES=service.instance.id=123
       - OTEL_EXPORTER_OTLP_ENDPOINT
       - OTEL_EXPORTER_OTLP_HEADERS
-      - OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT=4095
-      - OTEL_RESOURCE_ATTRIBUTES=service.instance.id=123
+      - OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT
+      - OTEL_EXPORTER_OTLP_COMPRESSION
+      - OTEL_EXPORTER_OTLP_PROTOCOL
+      - OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
     ports:
       - 8080
   go:
     build: go
     environment:
       - OTEL_SERVICE_NAME=getting-started-go
+      - OTEL_RESOURCE_ATTRIBUTES=service.instance.id=123
       - OTEL_EXPORTER_OTLP_ENDPOINT
       - OTEL_EXPORTER_OTLP_HEADERS
-      - OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT=4095
-      - OTEL_RESOURCE_ATTRIBUTES=service.instance.id=123
+      - OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT
+      - OTEL_EXPORTER_OTLP_COMPRESSION
+      - OTEL_EXPORTER_OTLP_PROTOCOL
+      - OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
     ports:
       - 8080
   java:
     build: java
     environment:
-      - OTEL_EXPORTER_OTLP_ENDPOINT
-      - OTEL_EXPORTER_OTLP_HEADERS
-      - OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT=4095
-      - OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=DELTA
+      - OTEL_SERVICE_NAME=getting-started-java
+      # No need to set service.instance.id because otel java agent generates random UUID
+      # - OTEL_RESOURCE_ATTRIBUTES=service.instance.id=123
       - OTEL_EXPERIMENTAL_EXPORTER_OTLP_RETRY_ENABLED=true
       - OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION=BASE2_EXPONENTIAL_BUCKET_HISTOGRAM
-      - OTEL_EXPORTER_OTLP_COMPRESSION=gzip
-      - OTEL_SERVICE_NAME=getting-started-java
       - OTEL_EXPERIMENTAL_RESOURCE_DISABLED_KEYS=process.command_args
+      - OTEL_EXPORTER_OTLP_ENDPOINT
+      - OTEL_EXPORTER_OTLP_HEADERS
+      - OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT
+      - OTEL_EXPORTER_OTLP_COMPRESSION
+      - OTEL_EXPORTER_OTLP_PROTOCOL
+      - OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
     ports:
       - 8080
   javascript:
     build: javascript
     environment:
       - OTEL_SERVICE_NAME=getting-started-javascript
+      - OTEL_RESOURCE_ATTRIBUTES=service.instance.id=123
       - OTEL_EXPORTER_OTLP_ENDPOINT
       - OTEL_EXPORTER_OTLP_HEADERS
-      - OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT=4095
-      - OTEL_RESOURCE_ATTRIBUTES=service.instance.id=123
+      - OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT
+      - OTEL_EXPORTER_OTLP_COMPRESSION
+      - OTEL_EXPORTER_OTLP_PROTOCOL
+      - OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
     ports:
       - 8080
   python:
     build: python
     environment:
       - OTEL_SERVICE_NAME=getting-started-python
+      - OTEL_RESOURCE_ATTRIBUTES=service.instance.id=123
       - OTEL_EXPORTER_OTLP_ENDPOINT
       - OTEL_EXPORTER_OTLP_HEADERS
-      - OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT=4095
-      - OTEL_RESOURCE_ATTRIBUTES=service.instance.id=123
+      - OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT
+      - OTEL_EXPORTER_OTLP_COMPRESSION
+      - OTEL_EXPORTER_OTLP_PROTOCOL
+      - OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
     ports:
       - 8080
   ruby:
     build: ruby
     environment:
       - OTEL_SERVICE_NAME=getting-started-ruby
+      - OTEL_RESOURCE_ATTRIBUTES=service.instance.id=123
       - OTEL_EXPORTER_OTLP_ENDPOINT
       - OTEL_EXPORTER_OTLP_HEADERS
-      - OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT=4095
-      - OTEL_RESOURCE_ATTRIBUTES=service.instance.id=123
+      - OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT
+      - OTEL_EXPORTER_OTLP_COMPRESSION
+      - OTEL_EXPORTER_OTLP_PROTOCOL
+      # Ruby doesn't support metrics yet
+      # - OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
     ports:
       - 8080
   envoy:

--- a/getting-started-guides/dotnet/README.md
+++ b/getting-started-guides/dotnet/README.md
@@ -15,11 +15,13 @@ It demonstrates how to configure OpenTelemetry .NET to send data to New Relic.
    data to New Relic:
 
     ```shell
+    export OTEL_SERVICE_NAME=getting-started-dotnet
     export OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.nr-data.net
     export OTEL_EXPORTER_OTLP_HEADERS=api-key=<your_license_key>
     export OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT=4095
-    export OTEL_SERVICE_NAME=getting-started-dotnet
-    export OTEL_RESOURCE_ATTRIBUTES=service.instance.id=123
+    export OTEL_EXPORTER_OTLP_COMPRESSION=gzip
+    export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+    export OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta
     ```
 
     * If your account is based in the EU, set the endpoint to: [https://otlp.eu01.nr-data.net](https://otlp.eu01.nr-data.net)

--- a/getting-started-guides/go/README.md
+++ b/getting-started-guides/go/README.md
@@ -15,11 +15,15 @@ It demonstrates how to configure OpenTelemetry Go to send data to New Relic.
    data to New Relic:
 
     ```shell
+    export OTEL_SERVICE_NAME=getting-started-go
+    export OTEL_RESOURCE_ATTRIBUTES=service.instance.id=123
     export OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.nr-data.net
     export OTEL_EXPORTER_OTLP_HEADERS=api-key=<your_license_key>
     export OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT=4095
-    export OTEL_SERVICE_NAME=getting-started-go
-    export OTEL_RESOURCE_ATTRIBUTES=service.instance.id=123
+    export OTEL_EXPORTER_OTLP_COMPRESSION=gzip
+    export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+    export OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta
+
     ```
 
     * If your account is based in the EU, set the endpoint to: [https://otlp.eu01.nr-data.net](https://otlp.eu01.nr-data.net)

--- a/getting-started-guides/java/README.md
+++ b/getting-started-guides/java/README.md
@@ -16,15 +16,16 @@ It demonstrates how to configure OpenTelemetry Java to send data to New Relic.
    data to New Relic:
 
     ```shell
+    export OTEL_SERVICE_NAME=getting-started-java
+    export OTEL_EXPERIMENTAL_EXPORTER_OTLP_RETRY_ENABLED=true
+    export OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION=BASE2_EXPONENTIAL_BUCKET_HISTOGRAM
+    export OTEL_EXPERIMENTAL_RESOURCE_DISABLED_KEYS=process.command_args
     export OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.nr-data.net
     export OTEL_EXPORTER_OTLP_HEADERS=api-key=<your_license_key>
     export OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT=4095
-    export OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=DELTA
-    export OTEL_EXPERIMENTAL_EXPORTER_OTLP_RETRY_ENABLED=true
-    export OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION=BASE2_EXPONENTIAL_BUCKET_HISTOGRAM
     export OTEL_EXPORTER_OTLP_COMPRESSION=gzip
-    export OTEL_SERVICE_NAME=getting-started-java
-    export OTEL_EXPERIMENTAL_RESOURCE_DISABLED_KEYS=process.command_args
+    export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+    export OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta
     ```
 
     * If your account is based in the EU, set the endpoint to: [https://otlp.eu01.nr-data.net](https://otlp.eu01.nr-data.net)

--- a/getting-started-guides/javascript/README.md
+++ b/getting-started-guides/javascript/README.md
@@ -15,11 +15,14 @@ It demonstrates how to configure OpenTelemetry JavaScript to send data to New Re
    data to New Relic:
 
     ```shell
+    export OTEL_SERVICE_NAME=getting-started-nodejs
+    export OTEL_RESOURCE_ATTRIBUTES=service.instance.id=123
     export OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.nr-data.net
     export OTEL_EXPORTER_OTLP_HEADERS=api-key=<your_license_key>
     export OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT=4095
-    export OTEL_SERVICE_NAME=getting-started-nodejs
-    export OTEL_RESOURCE_ATTRIBUTES=service.instance.id=123
+    export OTEL_EXPORTER_OTLP_COMPRESSION=gzip
+    export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+    export OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta
     ```
 
     * If your account is based in the EU, set the endpoint to: [https://otlp.eu01.nr-data.net](https://otlp.eu01.nr-data.net)

--- a/getting-started-guides/python/README.md
+++ b/getting-started-guides/python/README.md
@@ -15,12 +15,15 @@ It demonstrates how to configure OpenTelemetry Python to send data to New Relic.
    data to New Relic:
 
     ```shell
+    export OTEL_SERVICE_NAME=getting-started-python
+    export OTEL_RESOURCE_ATTRIBUTES=service.instance.id=123
     export OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
     export OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.nr-data.net
     export OTEL_EXPORTER_OTLP_HEADERS=api-key=<your_license_key>
     export OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT=4095
-    export OTEL_SERVICE_NAME=getting-started-python
-    export OTEL_RESOURCE_ATTRIBUTES=service.instance.id=123
+    export OTEL_EXPORTER_OTLP_COMPRESSION=gzip
+    export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf 
+    export OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta
     ```
 
     * If your account is based in the EU, set the endpoint to: [https://otlp.eu01.nr-data.net](https://otlp.eu01.nr-data.net)

--- a/getting-started-guides/ruby/README.md
+++ b/getting-started-guides/ruby/README.md
@@ -15,11 +15,13 @@ It demonstrates how to configure OpenTelemetry Ruby to send data to New Relic.
    data to New Relic:
 
     ```shell
+    export OTEL_SERVICE_NAME=getting-started-ruby
+    export OTEL_RESOURCE_ATTRIBUTES=service.instance.id=123
     export OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.nr-data.net
     export OTEL_EXPORTER_OTLP_HEADERS=api-key=<your_license_key>
     export OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT=4095
-    export OTEL_SERVICE_NAME=getting-started-ruby
-    export OTEL_RESOURCE_ATTRIBUTES=service.instance.id=123
+    export OTEL_EXPORTER_OTLP_COMPRESSION=gzip
+    export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
     ```
 
     * If your account is based in the EU, set the endpoint to: [https://otlp.eu01.nr-data.net](https://otlp.eu01.nr-data.net)


### PR DESCRIPTION
The python getting started example wasn't working because it required the otlp protocol to be set to `http/protobuf`.

Other examples weren't emitting delta metrics.

Other examples weren't setting compression to gzip.

This PR fixes issues and normalizes the set of env vars and their order for improved maintainability.