### PR TITLE
Remove redundant boms from java

### DIFF
--- a/getting-started-guides/java/build.gradle
+++ b/getting-started-guides/java/build.gradle
@@ -27,14 +27,18 @@ configurations {
   agent
 }
 
+def otelInstrumentationVersion = "2.6.0-alpha";
+
 dependencies {
   implementation platform(SpringBootPlugin.BOM_COORDINATES)
   implementation 'org.springframework.boot:spring-boot-starter-web'
 
-  implementation("io.opentelemetry:opentelemetry-api:1.40.0")
+  implementation platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:${otelInstrumentationVersion}")
+  implementation("io.opentelemetry:opentelemetry-api")
 
   // Add OpenTelemetry java agent to the "agent" configuration we previously defined
-  agent("io.opentelemetry.javaagent:opentelemetry-javaagent:2.6.0")
+  agent(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:${otelInstrumentationVersion}"))
+  agent("io.opentelemetry.javaagent:opentelemetry-javaagent")
 }
 
 tasks.register("copyAgent", Copy) {

--- a/other-examples/java/agent-nr-config/application/build.gradle
+++ b/other-examples/java/agent-nr-config/application/build.gradle
@@ -16,7 +16,8 @@ configurations {
 dependencies {
   implementation 'io.opentelemetry:opentelemetry-api'
 
-  agent("io.opentelemetry.javaagent:opentelemetry-javaagent:2.6.0")
+  agent(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:${project.property('otelInstrumentationVersion')}"))
+  agent("io.opentelemetry.javaagent:opentelemetry-javaagent")
 
   implementation platform(SpringBootPlugin.BOM_COORDINATES)
   implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -41,9 +42,6 @@ bootRun {
   def extensionPath = project(":agent-nr-config:config-extension").buildDir.toString() + "/libs/config-extension.jar"
 
   def agentPath = project.buildDir.toString() + "/agent/opentelemetry-javaagent.jar"
-
-  println(agentPath)
-  println(extensionPath)
 
   jvmArgs = [
       // Set the opentelemetry-java-instrumentation agent as the javaagent

--- a/other-examples/java/build.gradle
+++ b/other-examples/java/build.gradle
@@ -2,6 +2,8 @@ plugins {
   id 'com.diffplug.spotless' apply false
 }
 
+def otelInstrumentationVersion = "2.6.0-alpha";
+
 subprojects {
   pluginManager.withPlugin('java') {
     apply plugin: 'com.diffplug.spotless'
@@ -28,9 +30,10 @@ subprojects {
       useJUnitPlatform()
     }
 
+    ext.otelInstrumentationVersion = otelInstrumentationVersion;
+
     dependencies {
-      implementation platform("io.opentelemetry:opentelemetry-bom-alpha:1.40.0-alpha")
-      implementation platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.6.0-alpha")
+      implementation platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:${otelInstrumentationVersion}")
     }
   }
 }

--- a/other-examples/java/micrometer-shim/build.gradle
+++ b/other-examples/java/micrometer-shim/build.gradle
@@ -12,10 +12,10 @@ bootRun {
 dependencies {
   implementation 'io.opentelemetry:opentelemetry-api'
   implementation 'io.opentelemetry:opentelemetry-sdk'
+  implementation 'io.opentelemetry:opentelemetry-exporter-otlp'
 
   //alpha modules
   implementation 'io.opentelemetry.instrumentation:opentelemetry-micrometer-1.5'
-  implementation 'io.opentelemetry:opentelemetry-exporter-otlp'
 
   //spring modules
   implementation platform(SpringBootPlugin.BOM_COORDINATES)


### PR DESCRIPTION
Reduce the dependabot noise when otel java releases occur by grouping dependencies together. 