### PR TITLE
Add APM service correlation to docker stats receiver example

### DIFF
--- a/other-examples/collector/docker/docker-compose.yaml
+++ b/other-examples/collector/docker/docker-compose.yaml
@@ -1,6 +1,7 @@
 version: '3'
 services:
   collector:
+    container_name: docker-collector
     image: otel/opentelemetry-collector-contrib:0.98.0
     volumes:
     - ./config.yaml:/etc/otelcol-contrib/config.yaml
@@ -15,6 +16,13 @@ services:
       # Optionally manually set it if one of the resource detectors in config.yaml is unable to identify it.
       # - OTEL_RESOURCE_ATTRIBUTES=host.id=<INSERT_HOST_ID>
 
-  # Run a dummy nginx image to generate more interesting data.
-  nginx:
-    image: nginx
+  adservice:
+    container_name: docker-adservice
+    image: otel/demo:1.10.0-adservice
+    ports:
+      - "8080:8080"
+    environment:
+      - AD_SERVICE_PORT=8080
+      - OTEL_SERVICE_NAME=adservice
+      - OTEL_EXPORTER_OTLP_ENDPOINT=${NEW_RELIC_OTLP_ENDPOINT}
+      - OTEL_EXPORTER_OTLP_HEADERS=api-key=${NEW_RELIC_API_KEY}


### PR DESCRIPTION
Following pattern in #710.