### PR TITLE
feat: adding nrdot k8s host collector example

### DIFF
--- a/other-examples/collector/host-monitoring/README.md
+++ b/other-examples/collector/host-monitoring/README.md
@@ -51,7 +51,7 @@ Additionally, it demonstrates correlating APM entities with hosts, using the Ope
 To review your host data in New Relic, navigate to "New Relic -> All Entities -> Hosts" and click on the instance with name corresponding to the collector pod name to view the instance summary. Use [NRQL](https://docs.newrelic.com/docs/query-your-data/explore-query-data/get-started/introduction-querying-new-relic-data/) to perform ad-hoc analysis.
 
 ```
-FROM Metric SELECT uniques(metricName) WHERE otel.library.name like 'otelcol/hostmetricsreceiver/%'
+FROM Metric SELECT uniques(metricName) WHERE otel.library.name like '%/receiver/hostmetricsreceiver%'
 ```
 
 See [get started with querying](https://docs.newrelic.com/docs/query-your-data/explore-query-data/get-started/introduction-querying-new-relic-data/) for additional details on querying data in New Relic.

--- a/other-examples/collector/host-monitoring/k8s/collector.yaml
+++ b/other-examples/collector/host-monitoring/k8s/collector.yaml
@@ -10,7 +10,14 @@ metadata:
 data:
   collector-config: |
     receivers:
-      # Keep configuration in sync with: https://github.com/newrelic/opentelemetry-collector-releases/blob/main/configs/nr-otel-collector-agent-linux.yaml
+      # Keep configuration in sync with: https://github.com/newrelic/nrdot-collector-releases/blob/main/distributions/nrdot-collector-host/config.yaml
+      otlp:
+        protocols:
+          grpc:
+          http:
+            # By default, the otlp receiver is configured to listen on localhost at port 4318, we need to change this to listen on the pod IP.
+            endpoint: ${env:MY_POD_IP}:4318
+      
       hostmetrics:
         root_path: /hostfs
         # Default collection interval is 60s. Lower if you need finer granularity.
@@ -78,15 +85,8 @@ data:
           - /var/log/messages
           - /var/log/secure
           - /var/log/yum.log
-      
-      otlp:
-        protocols:
-          http:
-          grpc:
-    
-    processors:
-      batch:
-    
+
+    processors:    
       # group system.cpu metrics by cpu
       metricstransform:
         transforms:
@@ -102,7 +102,7 @@ data:
               - action: aggregate_labels
                 label_set: [ direction ]
                 aggregation_type: sum
-    
+
       # remove system.cpu metrics for states
       filter/exclude_cpu_utilization:
         metrics:
@@ -165,15 +165,34 @@ data:
     
       cumulativetodelta:
     
-      transform:
+      transform/host:
         metric_statements:
           - context: metric
             statements:
               - set(description, "")
               - set(unit, "")
     
+      transform:
+        trace_statements:
+          - context: span
+            statements:
+              - truncate_all(attributes, 4095)
+              - truncate_all(resource.attributes, 4095)
+        log_statements:
+          - context: log
+            statements:
+              - truncate_all(attributes, 4095)
+              - truncate_all(resource.attributes, 4095)
+    
+      # used to prevent out of memory situations on the collector
+      memory_limiter:
+        check_interval: 1s
+        limit_mib: ${env:NEW_RELIC_MEMORY_LIMIT_MIB:-100}
+    
+      batch:
+    
       resourcedetection:
-        detectors: ["env", "system"]
+        detectors: ["system"]
         system:
           hostname_sources: ["os"]
           resource_attributes:
@@ -187,20 +206,28 @@ data:
           resource_attributes:
             host.name:
               enabled: false
-
+    
+      # Gives OTEL_RESOURCE_ATTRIBUTES precedence over other sources.
+      # host.id is set from env whenever the collector is orchestrated by NR Agents.
+      resourcedetection/env:
+        detectors: ["env"]
+        timeout: 2s
+        override: true
+    
     exporters:
       debug:
         verbosity: detailed
-      otlphttp:
-        endpoint: ${NEW_RELIC_OTLP_ENDPOINT}
+      otlphttp/newrelic:
+        endpoint: ${env:NEW_RELIC_OTLP_ENDPOINT:-https://otlp.nr-data.net}
         headers:
-          api-key: ${NEW_RELIC_API_KEY}
-
+          api-key: ${env:NEW_RELIC_API_KEY}
+    
     service:
       pipelines:
         metrics/host:
           receivers: [hostmetrics]
           processors:
+            - memory_limiter
             - metricstransform
             - filter/exclude_cpu_utilization
             - filter/exclude_memory_utilization
@@ -211,28 +238,29 @@ data:
             - filter/exclude_system_disk
             - filter/exclude_network
             - attributes/exclude_system_paging
-            - transform
+            - transform/host
             - resourcedetection
-            - resourcedetection/cloud 
+            - resourcedetection/cloud
+            - resourcedetection/env
             - cumulativetodelta
             - batch
-          exporters: [otlphttp]
+          exporters: [otlphttp/newrelic]
         logs/host:
           receivers: [filelog]
-          processors: [resourcedetection, resourcedetection/cloud, batch]
-          exporters: [otlphttp]
+          processors: [transform, resourcedetection, resourcedetection/cloud, resourcedetection/env, batch]
+          exporters: [otlphttp/newrelic]
         traces:
           receivers: [otlp]
-          processors: [resourcedetection, resourcedetection/cloud, batch]
-          exporters: [otlphttp]
+          processors: [transform, resourcedetection, resourcedetection/cloud, resourcedetection/env, batch]
+          exporters: [otlphttp/newrelic]
         metrics:
           receivers: [otlp]
-          processors: [resourcedetection, resourcedetection/cloud, batch]
-          exporters: [otlphttp]
+          processors: [transform, resourcedetection, resourcedetection/cloud, resourcedetection/env, batch]
+          exporters: [otlphttp/newrelic]
         logs:
           receivers: [otlp]
-          processors: [resourcedetection, resourcedetection/cloud, batch]
-          exporters: [otlphttp]
+          processors: [transform, resourcedetection, resourcedetection/cloud, resourcedetection/env, batch]
+          exporters: [otlphttp/newrelic]
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -252,7 +280,7 @@ spec:
     spec:
       containers:
         - name: collector
-          image: otel/opentelemetry-collector-contrib:0.98.0
+          image: otel/opentelemetry-collector-contrib:0.122.1
           env:
             # The default US endpoint is set here. You can change the endpoint and port based on your requirements if needed.
             # docs: https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-otlp/#configure-endpoint-port-protocol
@@ -273,6 +301,10 @@ spec:
             # We enabled the "env" resource detector and set host.id to the name of the node via env var.
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: host.id=$(NODE_NAME)
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           volumeMounts:
             - name: collector-config-vol
               mountPath: /etc/otelcol-contrib

--- a/other-examples/collector/nrdot-host-monitoring/README.md
+++ b/other-examples/collector/nrdot-host-monitoring/README.md
@@ -2,7 +2,7 @@
 
 This example demonstrates monitoring hosts with the [NRDOT collector](https://docs.newrelic.com/docs/opentelemetry/nrdot/nrdot-intro/), using the [host metrics receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver) and sending the data to New Relic via OTLP.
 
-Functionally this example is similar to the [host monitoring example]() but using the pre-packaged configuration of the NRDOT collector.
+Functionally this example is similar to the [host monitoring example](../host-monitoring/README.md) but using the pre-packaged configuration of the NRDOT collector.
 
 
 ## Requirements

--- a/other-examples/collector/nrdot-host-monitoring/README.md
+++ b/other-examples/collector/nrdot-host-monitoring/README.md
@@ -1,0 +1,58 @@
+# Monitoring Hosts with OpenTelemetry Collector
+
+This example demonstrates monitoring hosts with the [NRDOT collector](https://docs.newrelic.com/docs/opentelemetry/nrdot/nrdot-intro/), using the [host metrics receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver) and sending the data to New Relic via OTLP.
+
+Functionally this example is similar to the [host monitoring example]() but using the pre-packaged configuration of the NRDOT collector.
+
+
+## Requirements
+
+* You need to have a Kubernetes cluster, and the kubectl command-line tool must be configured to communicate with your cluster. Docker desktop [includes a standalone Kubernetes server and client](https://docs.docker.com/desktop/kubernetes/) which is useful for local testing.
+* [A New Relic account](https://one.newrelic.com/)
+* [A New Relic license key](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#license-key)
+
+## Running the example
+
+1. Update the `NEW_RELIC_API_KEY` value in [secrets.yaml](./k8s/secrets.yaml) to your New Relic license key.
+    ```yaml
+    # ...omitted for brevity
+    stringData:
+      # New Relic API key to authenticate the export requests.
+      # docs: https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#license-key
+      NEW_RELIC_API_KEY: <INSERT_API_KEY>
+    ```
+   
+    * Note, be careful to avoid inadvertent secret sharing when modifying `secrets.yaml`. To ignore changes to this file from git, run `git update-index --skip-worktree k8s/secrets.yaml`.
+
+    * If your account is based in the EU, update the `NEW_RELIC_OTLP_ENDPOINT` value in [collector.yaml](./k8s/collector.yaml) the endpoint to: [https://otlp.eu01.nr-data.net](https://otlp.eu01.nr-data.net)
+
+    ```yaml
+    # ...omitted for brevity
+   env:
+     # The default US endpoint is set here. You can change the endpoint and port based on your requirements if needed.
+     # docs: https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-otlp/#configure-endpoint-port-protocol
+     - name: NEW_RELIC_OTLP_ENDPOINT
+       value: https://otlp.eu01.nr-data.net
+    ```
+
+3. Run the application with the following command.
+
+    ```shell
+    kubectl apply -f k8s/
+    ```
+   
+   * When finished, cleanup resources with the following command. This is also useful to reset if modifying configuration.
+
+   ```shell
+   kubectl delete -f k8s/
+   ```
+
+## Viewing your data
+
+To review your host data in New Relic, navigate to "New Relic -> All Entities -> Hosts" and click on the instance with name corresponding to the collector pod name to view the instance summary. Use [NRQL](https://docs.newrelic.com/docs/query-your-data/explore-query-data/get-started/introduction-querying-new-relic-data/) to perform ad-hoc analysis.
+
+```
+FROM Metric SELECT uniques(metricName) WHERE otel.library.name like '%/receiver/hostmetricsreceiver/%'
+```
+
+See [get started with querying](https://docs.newrelic.com/docs/query-your-data/explore-query-data/get-started/introduction-querying-new-relic-data/) for additional details on querying data in New Relic.

--- a/other-examples/collector/nrdot-host-monitoring/k8s/_namespace.yaml
+++ b/other-examples/collector/nrdot-host-monitoring/k8s/_namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nr-nrdot-host-monitoring

--- a/other-examples/collector/nrdot-host-monitoring/k8s/adservice.yaml
+++ b/other-examples/collector/nrdot-host-monitoring/k8s/adservice.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: adservice
+  namespace: nr-nrdot-host-monitoring
+  labels:
+    app.kubernetes.io/name: adservice
+spec:
+  containers:
+    - name: adservice
+      image: otel/demo:1.10.0-adservice
+      env:
+        - name: AD_SERVICE_PORT
+          value: "8080"
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(HOST_IP):4318
+        - name: OTEL_SERVICE_NAME
+          value: adservice
+      ports:
+        - containerPort: 8080

--- a/other-examples/collector/nrdot-host-monitoring/k8s/collector.yaml
+++ b/other-examples/collector/nrdot-host-monitoring/k8s/collector.yaml
@@ -1,0 +1,63 @@
+
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: collector
+  namespace: nr-nrdot-host-monitoring
+  labels:
+    app.kubernetes.io/name: collector
+spec:
+  selector:
+    matchLabels:
+      name: collector
+  template:
+    metadata:
+      labels:
+        name: collector
+    spec:
+      containers:
+        - name: collector
+          image: newrelic/nrdot-collector-host:1.0.2
+          args:
+            - --config=/etc/nrdot-collector-host/config.yaml
+            # The root path of the host filesystem. This is required by the hostmetrics receiver and not set by default in the nrdot-collector-host config.
+            - "--config=yaml:receivers::hostmetrics::root_path: /hostfs"
+            # By default, the otlp receiver is configured to listen on localhost at port 4318, we need to change this to listen on the pod IP.
+            - "--config=yaml:receivers::otlp::protocols::http::endpoint: ${env:MY_POD_IP}:4318"
+          env:
+            # The default US endpoint is set here. You can change the endpoint and port based on your requirements if needed.
+            # docs: https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-otlp/#configure-endpoint-port-protocol
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: https://otlp.nr-data.net/
+            # The New Relic API key used to authenticate export requests.
+            # Defined in secrets.yaml
+            - name: NEW_RELIC_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: nr-nrdot-host-monitoring-secret
+                  key: NEW_RELIC_API_KEY
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # host.id is required for NewRelic host entity synthesis and relationships, but is not included by any resourcedetection detector when running with docker on macOS.
+            # We enabled the "env" resource detector and set host.id to the name of the node via env var.
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: host.id=$(NODE_NAME)
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          volumeMounts:
+            - name: hostfs
+              mountPath: /hostfs
+              readOnly: true
+              mountPropagation: HostToContainer
+          ports:
+            - containerPort: 4318
+              hostPort: 4318
+      volumes:
+        - name: hostfs
+          hostPath:
+            path: /

--- a/other-examples/collector/nrdot-host-monitoring/k8s/secrets.yaml
+++ b/other-examples/collector/nrdot-host-monitoring/k8s/secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nr-nrdot-host-monitoring-secret
+  namespace: nr-nrdot-host-monitoring
+stringData:
+  # New Relic API key to authenticate the export requests.
+  # docs: https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#license-key
+  NEW_RELIC_API_KEY: <INSERT_API_KEY>


### PR DESCRIPTION
Adds `nrdot-host-monitoring` to the collector examples, effectively mirrors the `host-monitoring` example but relying on the disto provided config.  Also updates the `host-monitoring` example collector image to `0.121.0` and updates the config to match `nrdot-collector-host`.

Will need to wait for https://github.com/newrelic/docs-website/pull/20202 to be merged in order for CI to pass