### PR TITLE
docs: add container relationship example for collector

### DIFF
--- a/other-examples/collector/internal-telemetry-k8s-container-relationships/README.md
+++ b/other-examples/collector/internal-telemetry-k8s-container-relationships/README.md
@@ -1,0 +1,119 @@
+# Monitoring the OpenTelemetry Collector with Container Relationships
+
+The OpenTelemetry Collector can be configured to emit its [internal telemetry](https://opentelemetry.io/docs/collector/internal-telemetry/). This enables you to observe and monitor the health of your collectors. This example demonstrates how to configure the collector's internal telemetry and send it to New Relic to light up New Relic's collector observability experience. The example also demonstrates how to create a relationship between the collector and its Kubernetes container in New Relic.
+
+## Requirements
+
+- You need to have a Kubernetes cluster, and the kubectl command-line tool must be configured to communicate with your cluster. This example was tested on [AWS EKS](https://aws.amazon.com/eks/) with Amazon Linux nodes. The steps for achieving a container relationship should be universal for all k8s clusters - they also work on local clusters like `kind` or `minikube`.
+- Your infrastructure must be instrumented with one of our OTel infrastructure agents. We recommend using the [nr-k8s-otel-collector](https://github.com/newrelic/helm-charts/tree/master/charts/nr-k8s-otel-collector) helm chart which provides container monitoring.
+- [A New Relic account](https://one.newrelic.com/)
+- [A New Relic license key](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#license-key)
+
+### Collector
+
+We'll use [otelcol-contrib](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/v0.142.0/distributions/otelcol-contrib) for the example.
+
+The internal telemetry is configured to send directly to New Relic's OTLP endpoint without going through the collector's own pipeline.
+
+### Appendix
+
+- Collector entity definition: [EXT-SERVICE](https://github.com/newrelic/entity-definitions/blob/main/entity-types/ext-service/definition.yml#L72-L94)
+  - requires `service.name` on internal telemetry
+- Collector to container relationship: [INFRA_KUBERNETES_CONTAINER-to-EXT_SERVICE](https://github.com/newrelic/entity-definitions/blob/main/relationships/synthesis/INFRA_KUBERNETES_CONTAINER-to-EXT_SERVICE.yml#L40)
+  - requires `k8s.cluster.name`, `k8s.namespace.name`, `k8s.pod.name`, `k8s.container.name` on internal telemetry that matches equivalent attributes on the container telemetry.
+
+
+## Running the example
+
+1. Instrument your containers with [nr-k8s-otel-collector](https://github.com/newrelic/helm-charts/tree/master/charts/nr-k8s-otel-collector).
+    ```shell
+      # Cluster name is hard coded as the downward API does not expose it
+      license_key='INSERT_API_KEY'
+      cluster_name='INSERT_CLUSTER_NAME'
+      helm repo add newrelic https://helm-charts.newrelic.com
+      helm upgrade 'nr-k8s-otel-collector-release' newrelic/nr-k8s-otel-collector \
+      --install \
+      --version '0.9.8' \
+      --create-namespace --namespace 'newrelic' \
+      --dependency-update \
+      --set "cluster=${cluster_name}" \
+      --set "licenseKey=${license_key}"
+    ```
+1. Create your secrets file from the template and update the values:
+    ```shell
+    cp k8s/secrets.yaml.template k8s/secrets.yaml
+    # Edit k8s/secrets.yaml with your actual API key and cluster name
+    ```
+    * Make sure that the cluster name matches the value above and, if you have multiple accounts, that the license key reports to the same account.
+
+1. Deploy the collector, see `collector.yaml` - we're using [contrib](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/v0.142.0/distributions/otelcol-contrib) as an example.
+
+    ```shell
+    kubectl apply -f k8s/
+    ```
+   
+1. When finished, cleanup resources with the following command. This is also useful to reset if modifying configuration.
+
+   ```shell
+   kubectl delete -f k8s/
+   helm uninstall 'nr-k8s-otel-collector-release' --namespace 'newrelic'
+   ```
+
+## Viewing your data
+
+### In the UI
+
+The infrastructure relationships are used to light up our APM UI. Navigate to "New Relic -> All Entities -> Services - OpenTelemetry" and click on the service with name corresponding to value provided in `secrets.yaml` for `COLLECTOR_SERVICE_NAME`. The 'Summary' page shows metrics related to the infrastructure entities related to your collector at the bottom of the page.
+
+### From the CLI
+You can also query the relationships through NerdGraph using the [newrelic CLI](https://github.com/newrelic/newrelic-cli/blob/main/docs/GETTING_STARTED.md#environment-setup). Note that the api key in this case is NOT an ingest key (as used above), but instead a user key.
+
+The following script should work if your service name is sufficiently unique as the first part determines the entity guid based on the service name.
+If you have the correct entity guid, you can skip the first part and just query the relationships directly.
+
+```bash
+#!/bin/bash
+export NEW_RELIC_REGION='US'
+export NEW_RELIC_API_KEY='INSERT_USER_KEY'
+SERVICE_NAME='INSERT_SERVICE_NAME'
+
+ENTITY=$(newrelic nerdgraph query "{
+  actor {
+    entitySearch(queryBuilder: {name: \"${SERVICE_NAME}\"}) {
+      results {
+        entities {
+          guid
+          name
+        }
+      }
+    }
+  }
+}")
+SERVICE_ENTITY_GUID=$(jq -r '.actor.entitySearch.results.entities[0].guid' <<< "$ENTITY")
+
+newrelic nerdgraph query "{
+  actor {
+    entity(guid: \"${SERVICE_ENTITY_GUID}\") {
+      relatedEntities(filter: {relationshipTypes: {include: HOSTS}}) {
+        results {
+          source {
+            entity {
+              name
+              guid
+              domain
+              type
+            }
+          }
+          type
+          target {
+            entity {
+              guid
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}" 
+```

--- a/other-examples/collector/internal-telemetry-k8s-container-relationships/README.md
+++ b/other-examples/collector/internal-telemetry-k8s-container-relationships/README.md
@@ -1,10 +1,10 @@
 # Monitoring the OpenTelemetry Collector with Container Relationships
 
-The OpenTelemetry Collector can be configured to emit its [internal telemetry](https://opentelemetry.io/docs/collector/internal-telemetry/). This enables you to observe and monitor the health of your collectors. This example demonstrates how to configure the collector's internal telemetry and send it to New Relic to light up New Relic's collector observability experience. The example also demonstrates how to create a relationship between the collector and its Kubernetes container in New Relic.
+The [internal-telemetry example](../internal-telemetry/README.md) showcases how to configure the OpenTelemetry Collector to emit its [internal telemetry](https://opentelemetry.io/docs/collector/internal-telemetry/) to New Relic. This example expands on that with k8s infrastructure monitoring, i.e. instrument the underlying containers and create relationships between the collector and its container. This enables New Relic to display container metrics directly in the collector observability experience.
 
 ## Requirements
 
-- You need to have a Kubernetes cluster, and the kubectl command-line tool must be configured to communicate with your cluster. This example was tested on [AWS EKS](https://aws.amazon.com/eks/) with Amazon Linux nodes. The steps for achieving a container relationship should be universal for all k8s clusters - they also work on local clusters like `kind` or `minikube`.
+- You need to have a Kubernetes cluster, and the kubectl command-line tool must be configured to communicate with your cluster.
 - Your infrastructure must be instrumented with one of our OTel infrastructure agents. We recommend using the [nr-k8s-otel-collector](https://github.com/newrelic/helm-charts/tree/master/charts/nr-k8s-otel-collector) helm chart which provides container monitoring.
 - [A New Relic account](https://one.newrelic.com/)
 - [A New Relic license key](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#license-key)
@@ -13,7 +13,7 @@ The OpenTelemetry Collector can be configured to emit its [internal telemetry](h
 
 We'll use [otelcol-contrib](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/v0.142.0/distributions/otelcol-contrib) for the example.
 
-The internal telemetry is configured to send directly to New Relic's OTLP endpoint without going through the collector's own pipeline.
+The internal telemetry is configured to be sent directly to New Relic's OTLP endpoint without going through the collector's own pipeline, so it should work for any collector use case.
 
 ### Appendix
 
@@ -28,8 +28,8 @@ The internal telemetry is configured to send directly to New Relic's OTLP endpoi
 1. Instrument your containers with [nr-k8s-otel-collector](https://github.com/newrelic/helm-charts/tree/master/charts/nr-k8s-otel-collector).
     ```shell
       # Cluster name is hard coded as the downward API does not expose it
-      license_key='INSERT_API_KEY'
       cluster_name='INSERT_CLUSTER_NAME'
+      license_key='INSERT_API_KEY'
       helm repo add newrelic https://helm-charts.newrelic.com
       helm upgrade 'nr-k8s-otel-collector-release' newrelic/nr-k8s-otel-collector \
       --install \
@@ -46,7 +46,7 @@ The internal telemetry is configured to send directly to New Relic's OTLP endpoi
     ```
     * Make sure that the cluster name matches the value above and, if you have multiple accounts, that the license key reports to the same account.
 
-1. Deploy the collector, see `collector.yaml` - we're using [contrib](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/v0.142.0/distributions/otelcol-contrib) as an example.
+1. Deploy the collector
 
     ```shell
     kubectl apply -f k8s/
@@ -65,8 +65,8 @@ The internal telemetry is configured to send directly to New Relic's OTLP endpoi
 
 The infrastructure relationships are used to light up our APM UI. Navigate to "New Relic -> All Entities -> Services - OpenTelemetry" and click on the service with name corresponding to value provided in `secrets.yaml` for `COLLECTOR_SERVICE_NAME`. The 'Summary' page shows metrics related to the infrastructure entities related to your collector at the bottom of the page.
 
-### From the CLI
-You can also query the relationships through NerdGraph using the [newrelic CLI](https://github.com/newrelic/newrelic-cli/blob/main/docs/GETTING_STARTED.md#environment-setup). Note that the api key in this case is NOT an ingest key (as used above), but instead a user key.
+### From the CLI (troubleshooting)
+You can also query the relationships through NerdGraph using the [newrelic CLI](https://github.com/newrelic/newrelic-cli/blob/main/docs/GETTING_STARTED.md#environment-setup). Note that the [API key](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/) in this case is NOT an ingest key (as used above), but instead a user key.
 
 The following script should work if your service name is sufficiently unique as the first part determines the entity guid based on the service name.
 If you have the correct entity guid, you can skip the first part and just query the relationships directly.

--- a/other-examples/collector/internal-telemetry-k8s-container-relationships/README.md
+++ b/other-examples/collector/internal-telemetry-k8s-container-relationships/README.md
@@ -1,6 +1,6 @@
 # Monitoring the OpenTelemetry Collector with Container Relationships
 
-The [internal-telemetry example](../internal-telemetry/README.md) showcases how to configure the OpenTelemetry Collector to emit its [internal telemetry](https://opentelemetry.io/docs/collector/internal-telemetry/) to New Relic. This example expands on that with k8s infrastructure monitoring, i.e. instrument the underlying containers and create relationships between the collector and its container. This enables New Relic to display container metrics directly in the collector observability experience.
+The [internal-telemetry example](https://github.com/newrelic/newrelic-opentelemetry-examples/tree/main/other-examples/collector/internal-telemetry) showcases how to configure the OpenTelemetry Collector to emit its [internal telemetry](https://opentelemetry.io/docs/collector/internal-telemetry/) to New Relic. This example expands on that with k8s infrastructure monitoring, i.e. instrument the underlying containers and create relationships between the collector and its container. This enables New Relic to display container metrics directly in the collector observability experience.
 
 ## Requirements
 

--- a/other-examples/collector/internal-telemetry-k8s-container-relationships/k8s/_namespace.yaml
+++ b/other-examples/collector/internal-telemetry-k8s-container-relationships/k8s/_namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: k8s-container-relationships

--- a/other-examples/collector/internal-telemetry-k8s-container-relationships/k8s/collector.yaml
+++ b/other-examples/collector/internal-telemetry-k8s-container-relationships/k8s/collector.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: collector
+  namespace: k8s-container-relationships
+  labels:
+    app.kubernetes.io/name: collector
+spec:
+  selector:
+    matchLabels:
+      name: collector
+  template:
+    metadata:
+      labels:
+        name: collector
+    spec:
+      containers:
+        - name: collector-container-relationship
+          image: otel/opentelemetry-collector-contrib:0.142.0
+          args:
+            - --config=/config/config.yaml
+          env:
+            # New Relic OTLP endpoint
+            - name: NEW_RELIC_OTLP_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: collector-internal-telemetry-secret
+                  key: NEW_RELIC_OTLP_ENDPOINT
+            # The New Relic API key used to authenticate export requests.
+            # Defined in secrets.yaml
+            - name: NEW_RELIC_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: collector-internal-telemetry-secret
+                  key: NEW_RELIC_API_KEY
+            # defines the collector's entity name in New Relic
+            - name: SERVICE_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: collector-internal-telemetry-secret
+                  key: COLLECTOR_SERVICE_NAME
+            - name: CLUSTER_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: collector-internal-telemetry-secret
+                  key: CLUSTER_NAME
+            # k8s.namespace.name from Downward API
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            # k8s.pod.name from Downward API
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            # k8s.container.name - must match the container's name above
+            - name: CONTAINER_NAME
+              value: collector-container-relationship
+          volumeMounts:
+            - name: config
+              mountPath: /config
+      volumes:
+        - name: config
+          configMap:
+            name: collector-config

--- a/other-examples/collector/internal-telemetry-k8s-container-relationships/k8s/configmap.yaml
+++ b/other-examples/collector/internal-telemetry-k8s-container-relationships/k8s/configmap.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: collector-config
+  namespace: k8s-container-relationships
+data:
+  config.yaml: |
+    receivers:
+      # Dummy receiver to allow the collector to start
+      otlp:
+        protocols:
+          http:
+
+    exporters:
+      # Dummy exporter to complete the pipeline
+      debug:
+
+    service:
+      pipelines:
+        # Dummy pipeline required for collector startup
+        metrics:
+          receivers: [otlp]
+          exporters: [debug]
+
+      telemetry:
+        # based on https://raw.githubusercontent.com/newrelic/nrdot-collector-releases/1.11.0/examples/internal-telemetry-config.yaml
+        resource:
+          service.name: "${env:SERVICE_NAME}"
+          newrelic.service.type: otel_collector
+          k8s.cluster.name: "${env:CLUSTER_NAME}"
+          k8s.namespace.name: "${env:NAMESPACE}"
+          k8s.pod.name: "${env:POD_NAME}"
+          k8s.container.name: "${env:CONTAINER_NAME}"
+        metrics:
+          level: detailed
+          readers:
+            - periodic:
+                exporter:
+                  otlp:
+                    protocol: http/protobuf
+                    endpoint: "${env:NEW_RELIC_OTLP_ENDPOINT}"
+                    headers:
+                      api-key: "${env:NEW_RELIC_LICENSE_KEY}"
+        logs:
+          level: INFO
+          processors:
+            - batch:
+                exporter:
+                  otlp:
+                    protocol: http/protobuf
+                    endpoint: "${env:NEW_RELIC_OTLP_ENDPOINT}"
+                    headers:
+                      api-key: "${env:NEW_RELIC_LICENSE_KEY}"

--- a/other-examples/collector/internal-telemetry-k8s-container-relationships/k8s/secrets.yaml.template
+++ b/other-examples/collector/internal-telemetry-k8s-container-relationships/k8s/secrets.yaml.template
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: collector-internal-telemetry-secret
+  namespace: k8s-container-relationships
+stringData:
+  # New Relic API key to authenticate the export requests.
+  # docs: https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#license-key
+  NEW_RELIC_API_KEY: INSERT_API_KEY
+  # The default US endpoint is set here. If your account is based in the EU, use `https://otlp.eu01.nr-data.net` instead.
+  # docs: https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-otlp/#configure-endpoint-port-protocol
+  NEW_RELIC_OTLP_ENDPOINT: https://otlp.nr-data.net/
+  # The cluster name; will be added as attribute `k8s.cluster.name` to the internal telemetry.
+  CLUSTER_NAME: INSERT_CLUSTER_NAME
+  # Determines the entity name in New Relic; will be added as `service.name` to internal telemetry.
+  COLLECTOR_SERVICE_NAME: collector-container-relationships
+


### PR DESCRIPTION
### Summary
- Add example showcasing how to configure internal telemetry of the collector to create container relationships on k8s. Container instrumentation is provided by `nr-k8s-otel-collector`.