### PR TITLE
chore: update global codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Global codeowners
 
-* @newrelic/opentelemetry-community
+* @newrelic/otelcomm
 
 getting-started-guides/dotnet/      @alanwest
 getting-started-guides/ruby/        @kaylareopelle


### PR DESCRIPTION
### Summary
- Team name changed to newrelic/otelcomm a while ago