### PR TITLE
feat: Add IBM MQ OTel monitoring example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ OpenTelemetry and New Relic.
 * [Monitor HCP Consul with Collector](./other-examples/collector/hcp-consul)
 * [Monitor HiveMQ with Collector](./other-examples/collector/hivemq)
 * [Monitor Hosts with Collector](./other-examples/collector/host-monitoring)
+* [Monitor IBM MQ with Collector](./infrastructure-monitoring/ibm-mq)
 * [Monitor Prometheus target with Collector](./other-examples/collector/prometheus)
 * [Monitor Redis with Collector](./other-examples/collector/redis)
 * [Monitor Singlestore with Collector](./other-examples/collector/singlestore)

--- a/infrastructure-monitoring/ibm-mq/.env.example
+++ b/infrastructure-monitoring/ibm-mq/.env.example
@@ -1,0 +1,27 @@
+# Copy to .env and fill in. Used by docker-compose.yaml.
+
+# Required — your New Relic ingest (license) key.
+NEW_RELIC_LICENSE_KEY=
+
+# OTLP/gRPC endpoint for your region:
+#   US prod   https://otlp.nr-data.net:4317
+#   EU prod   https://otlp.eu01.nr-data.net:4317
+#   JP prod   https://otlp.jp.nr-data.net:4317
+NEW_RELIC_OTLP_ENDPOINT=https://otlp.nr-data.net:4317
+
+# Optional — cluster name tag on your IBM MQ data. Leave empty to omit.
+IBMMQ_CLUSTER_NAME=
+
+# Optional — Prometheus scrape interval.
+IBMMQ_SCRAPE_INTERVAL=60s
+
+# Optional — queue manager name and dev credentials. If you change these, update mq_prometheus.yaml (the exporter config) to match.
+MQ_QMGR_NAME=QM1
+MQ_ADMIN_PASSWORD=passw0rd
+MQ_APP_PASSWORD=passw0rd
+
+# Optional — collector image (swap to otel/opentelemetry-collector-contrib:latest for upstream).
+OTEL_COLLECTOR_IMAGE=newrelic/nrdot-collector:latest
+
+# Optional — seconds between put/get cycles in the traffic generator.
+MESSAGE_INTERVAL_SECONDS=5

--- a/infrastructure-monitoring/ibm-mq/README.md
+++ b/infrastructure-monitoring/ibm-mq/README.md
@@ -124,8 +124,7 @@ The [config](./otel-collector-config.yaml) intentionally does **not** rename
 4. **Strips** a couple of collector-injected resource attributes (`service.name`,
    `url.scheme`) so metrics map to the IBM MQ entities, not the collector
    (host identity is kept).
-5. **Converts** cumulative counters to deltas (required by New Relic ingest).
-6. **Batches** and exports via OTLP.
+5. **Batches** and exports via OTLP.
 
 ## Related
 

--- a/infrastructure-monitoring/ibm-mq/README.md
+++ b/infrastructure-monitoring/ibm-mq/README.md
@@ -1,0 +1,134 @@
+# Monitoring IBM MQ with OpenTelemetry Collector
+
+Monitor IBM MQ with New Relic using OpenTelemetry. The
+[NRDOT Collector](https://github.com/newrelic/nrdot-collector-releases) scrapes
+the [`ibm-messaging/mq-metric-samples`](https://github.com/ibm-messaging/mq-metric-samples)
+Prometheus exporter and ships metrics to New Relic via OTLP.
+
+Metrics keep their native Prometheus shape (e.g. `ibmmq_queue_depth`, labels
+`qmgr` / `queue` / `channel`) so they map cleanly onto New Relic's IBM MQ entity
+definitions:
+
+- [`INFRA / IBMMQ_MANAGER`](https://github.com/newrelic/entity-definitions/tree/main/entity-types/infra-ibmmq_manager) — one per queue manager
+- [`INFRA / IBMMQ_QUEUE`](https://github.com/newrelic/entity-definitions/tree/main/entity-types/infra-ibmmq_queue) — one per (queue manager, queue)
+
+## Requirements
+
+- Docker and Docker Compose v2 (for the quick start)
+- A New Relic account and [ingest license key](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/)
+- An IBM MQ Prometheus exporter (`mq_prometheus`) reachable from the collector — the Docker Compose quick start builds one from source (needs internet access to fetch the IBM MQ redistributable client)
+
+## Architecture
+
+```
+IBM MQ Queue Manager (PCF) ──▶ mq-metric-samples exporter (:9157) ──▶ NRDOT Collector ──▶ New Relic (OTLP)
+```
+
+The exporter speaks PCF to the queue manager and exposes Prometheus; the
+collector scrapes Prometheus and exports OTLP. They are decoupled — either can be
+added to a host that already runs the other.
+
+The Docker Compose quick start builds the
+[`mq-metric-samples`](https://github.com/ibm-messaging/mq-metric-samples) exporter
+from source (there is no published image) and runs it against the queue manager
+with `objects.queues` / `objects.channels` and `useObjectStatus: true` (see
+[`mq_prometheus.yaml`](./mq_prometheus.yaml)). That full metric set — `ibmmq_qmgr_*`,
+`ibmmq_queue_*`, `ibmmq_channel_*` — synthesizes **both** the `IBMMQ_MANAGER` and
+`IBMMQ_QUEUE` entities.
+
+> **Note.** The IBM MQ container's built-in metrics endpoint (`MQ_ENABLE_METRICS`)
+> is queue-manager-level only (`ibmmq_qmgr_*` → `IBMMQ_MANAGER`). Per-queue metrics
+> and `IBMMQ_QUEUE` entities require the standalone exporter, which is why this
+> example builds and runs it.
+
+## Quick start (Docker Compose)
+
+Brings up IBM MQ, the `mq-metric-samples` exporter (built from source — the first
+`up` takes a few minutes), a small traffic generator (`mq-load`, which puts/gets
+messages on `DEV.QUEUE.1` so throughput/depth metrics move), and the collector.
+
+```bash
+cp .env.example .env
+# edit .env: set NEW_RELIC_LICENSE_KEY (and NEW_RELIC_OTLP_ENDPOINT for EU/JP)
+
+# build the exporter and start everything detached (the first build takes a few minutes)
+docker compose up -d --build
+
+# follow the logs if you like — Ctrl+C stops following, not the containers
+docker compose logs -f
+
+# verify IBM MQ metrics are being served (queue-manager + per-queue)
+curl -s http://localhost:9157/metrics | grep -E '^ibmmq_(qmgr|queue)'
+```
+
+Cleanup: `docker compose down -v`.
+
+> **Security.** MQ ports are published to `127.0.0.1` only — the web console
+> (`:9443`, default `admin`/`passw0rd`) and listener (`:1414`) aren't reachable
+> off-host. On a remote host (e.g. EC2), reach them via SSH tunnel, keep the
+> security group locked down, and change the default passwords for any non-demo use.
+
+## Use the collector against your own IBM MQ
+
+If you already run an IBM MQ exporter (`mq_prometheus`, default `localhost:9157`),
+run only the collector with [`otel-collector-config.yaml`](./otel-collector-config.yaml):
+
+```bash
+export NEW_RELIC_LICENSE_KEY="<your-key>"
+export IBMMQ_EXPORTER_ENDPOINT="localhost:9157"
+# export IBMMQ_CLUSTER_NAME="payments-cluster" # optional cluster tag
+# export NEW_RELIC_OTLP_ENDPOINT="https://otlp.eu01.nr-data.net:4317"  # non-US region (EU/JP)
+
+nrdot-collector --config otel-collector-config.yaml
+```
+
+The collector detects the host identity (`host.id` / `host.name`) automatically —
+no host-name configuration needed.
+
+Don't have an exporter yet? Build/run `mq_prometheus` from
+[`ibm-messaging/mq-metric-samples`](https://github.com/ibm-messaging/mq-metric-samples)
+pointed at your queue manager's `DEV.ADMIN.SVRCONN` (or a least-privilege
+monitoring channel in production).
+
+## Environment variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `NEW_RELIC_LICENSE_KEY` | Yes | — | New Relic ingest (license) key |
+| `IBMMQ_EXPORTER_ENDPOINT` | No | `localhost:9157` | IBM MQ exporter host:port |
+| `IBMMQ_CLUSTER_NAME` | No | _(absent)_ | Cluster name tag on the IBM MQ data. If unset, the tag is omitted. |
+| `IBMMQ_SCRAPE_INTERVAL` | No | `60s` | Prometheus scrape interval |
+| `NEW_RELIC_OTLP_ENDPOINT` | No | `https://otlp.nr-data.net:4317` | OTLP/gRPC endpoint (`https://otlp.eu01.nr-data.net:4317` EU, `https://otlp.jp.nr-data.net:4317` JP, `https://staging-otlp.nr-data.net:4317` staging) |
+
+## Verify in New Relic
+
+```sql
+-- confirm metrics are arriving (note the underscore-style names)
+FROM Metric SELECT uniques(metricName) WHERE metricName LIKE 'ibmmq_%' SINCE 10 minutes ago
+
+-- see all the IBM MQ dimensional data points that arrived, with every attribute
+FROM Metric SELECT * WHERE metricName LIKE 'ibmmq_%' SINCE 10 minutes ago
+```
+
+Then look under **All Entities → Infrastructure** for `IBMMQ_MANAGER` (one per
+queue manager) and its `IBMMQ_QUEUE` children.
+
+## How the pipeline keeps entity synthesis working
+
+The [config](./otel-collector-config.yaml) intentionally does **not** rename
+`ibmmq_*` metrics to `ibmmq.*` or rewrite labels like `qmgr`. It:
+
+1. **Scrapes** the exporter and detects host identity (`host.id` → entity identity, `host.name`).
+2. **Filters** exporter overhead (`go_*`, `process_*`, `promhttp_*`, `scrape_*`).
+3. **Filters** high-cardinality system queues (`SYSTEM.*`, `AMQ.*`).
+4. **Strips** a couple of collector-injected resource attributes (`service.name`,
+   `url.scheme`) so metrics map to the IBM MQ entities, not the collector
+   (host identity is kept).
+5. **Converts** cumulative counters to deltas (required by New Relic ingest).
+6. **Batches** and exports via OTLP.
+
+## Related
+
+- [IBM MQ metric samples](https://github.com/ibm-messaging/mq-metric-samples)
+- [OpenTelemetry Prometheus receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver)
+- [New Relic OTLP setup](https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/)

--- a/infrastructure-monitoring/ibm-mq/docker-compose.yaml
+++ b/infrastructure-monitoring/ibm-mq/docker-compose.yaml
@@ -1,0 +1,87 @@
+# IBM MQ + mq-metric-samples exporter + NRDOT collector -> New Relic.
+# Set NEW_RELIC_LICENSE_KEY in .env, then `docker compose up -d --build`.
+# The exporter is built from source on first run (no published image); it scrapes the
+# queue manager via PCF and serves ibmmq_qmgr_*/queue_*/channel_* on :9157, so you get
+# both IBMMQ_MANAGER and IBMMQ_QUEUE entities.
+
+services:
+  ibmmq:
+    image: ${IBMMQ_IMAGE:-icr.io/ibm-messaging/mq:latest}
+    container_name: ibmmq
+    environment:
+      LICENSE: accept
+      MQ_QMGR_NAME: ${MQ_QMGR_NAME:-QM1}
+      MQ_ADMIN_PASSWORD: ${MQ_ADMIN_PASSWORD:-passw0rd}
+      MQ_APP_PASSWORD: ${MQ_APP_PASSWORD:-passw0rd}
+    # Bound to 127.0.0.1 only — exporter/load reach MQ over the internal network; SSH-tunnel for remote access.
+    ports:
+      - "127.0.0.1:1414:1414"   # MQ listener
+      - "127.0.0.1:9443:9443"   # MQ web console (admin/passw0rd)
+    healthcheck:
+      # IBM MQ's built-in readiness check (the container has no curl).
+      test: ["CMD", "chkmqready"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 60s
+
+  # mq-metric-samples (mq_prometheus) exporter — built from source; no published image exists.
+  mq-exporter:
+    build:
+      context: "https://github.com/ibm-messaging/mq-metric-samples.git#v5.7.1"
+    image: ibmmq-mq-prometheus:v5.7.1
+    container_name: ibmmq-exporter
+    depends_on:
+      ibmmq:
+        condition: service_healthy
+    volumes:
+      - ./mq_prometheus.yaml:/opt/config/mq_prometheus.yaml:ro
+    ports:
+      - "127.0.0.1:9157:9157"   # Prometheus metrics (ibmmq_*)
+    restart: on-failure
+
+  # Generates traffic so the queue throughput/depth metrics (mqput/mqget) move.
+  mq-load:
+    image: ${IBMMQ_IMAGE:-icr.io/ibm-messaging/mq:latest}
+    container_name: ibmmq-load
+    depends_on:
+      ibmmq:
+        condition: service_healthy
+    environment:
+      LICENSE: accept
+      MQSERVER: "DEV.APP.SVRCONN/TCP/ibmmq(1414)"
+      MQSAMP_USER_ID: app
+      MQ_APP_PASSWORD: ${MQ_APP_PASSWORD:-passw0rd}
+      MQ_QMGR_NAME: ${MQ_QMGR_NAME:-QM1}
+      MESSAGE_INTERVAL_SECONDS: ${MESSAGE_INTERVAL_SECONDS:-5}
+    entrypoint: ["/bin/bash", "-c"]
+    command:
+      - |
+        while true; do
+          printf '%s\nIBM MQ demo message %s\n' "$$MQ_APP_PASSWORD" "$$(date +%s)" \
+            | /opt/mqm/samp/bin/amqsputc DEV.QUEUE.1 "$$MQ_QMGR_NAME" >/dev/null 2>&1 || true
+          printf '%s\n' "$$MQ_APP_PASSWORD" \
+            | timeout 3 /opt/mqm/samp/bin/amqsgetc DEV.QUEUE.1 "$$MQ_QMGR_NAME" >/dev/null 2>&1 || true
+          sleep "$$MESSAGE_INTERVAL_SECONDS"
+        done
+    restart: on-failure
+
+  nrdot-collector:
+    image: ${OTEL_COLLECTOR_IMAGE:-newrelic/nrdot-collector:latest}
+    container_name: nrdot-collector-ibmmq
+    environment:
+      NEW_RELIC_LICENSE_KEY: ${NEW_RELIC_LICENSE_KEY}
+      NEW_RELIC_OTLP_ENDPOINT: ${NEW_RELIC_OTLP_ENDPOINT:-https://otlp.nr-data.net:4317}
+      # Scrape the exporter over the compose network.
+      IBMMQ_EXPORTER_ENDPOINT: mq-exporter:9157
+      IBMMQ_SCRAPE_INTERVAL: ${IBMMQ_SCRAPE_INTERVAL:-60s}
+      # Optional cluster tag.
+      IBMMQ_CLUSTER_NAME: ${IBMMQ_CLUSTER_NAME:-}
+    volumes:
+      - ./otel-collector-config.yaml:/etc/nrdot-collector/otel-collector-config.yaml:ro
+    command:
+      - "--config=/etc/nrdot-collector/otel-collector-config.yaml"
+    depends_on:
+      mq-exporter:
+        condition: service_started
+    restart: unless-stopped

--- a/infrastructure-monitoring/ibm-mq/mq_prometheus.yaml
+++ b/infrastructure-monitoring/ibm-mq/mq_prometheus.yaml
@@ -1,0 +1,31 @@
+# mq-metric-samples (mq_prometheus) exporter config. Read at /opt/config/mq_prometheus.yaml.
+# Connects to the queue manager over a client channel (PCF) and serves ibmmq_* on :9157.
+# Defaults match .env (QM1 / admin / passw0rd) — update here too if you change them.
+global:
+  useObjectStatus: true   # publish per-queue and per-channel status metrics
+  usePublications: true
+  pollInterval: 60s
+  rediscoverInterval: 1h
+  logLevel: INFO
+
+connection:
+  queueManager: QM1
+  connName: ibmmq(1414)   # the MQ container, reached over the compose network
+  channel: DEV.ADMIN.SVRCONN
+  user: admin
+  password: passw0rd
+  clientConnection: true
+  replyQueue: SYSTEM.DEFAULT.MODEL.QUEUE
+
+objects:
+  # Monitor application queues; skip internal SYSTEM.*/AMQ.* (the collector filters them too).
+  queues:
+    - "*"
+    - "!SYSTEM.*"
+    - "!AMQ.*"
+  channels:
+    - "*"
+
+prometheus:
+  port: 9157
+  metricsPath: /metrics

--- a/infrastructure-monitoring/ibm-mq/otel-collector-config.yaml
+++ b/infrastructure-monitoring/ibm-mq/otel-collector-config.yaml
@@ -1,0 +1,92 @@
+# IBM MQ -> New Relic (NRDOT / OpenTelemetry Collector).
+# Scrapes the IBM MQ mq_prometheus exporter and ships ibmmq_* metrics via OTLP.
+# Run: nrdot-collector --config otel-collector-config.yaml
+# Env: NEW_RELIC_LICENSE_KEY (required); IBMMQ_EXPORTER_ENDPOINT (default localhost:9157);
+#      IBMMQ_CLUSTER_NAME (optional); NEW_RELIC_OTLP_ENDPOINT (default https://otlp.nr-data.net:4317).
+
+extensions:
+  health_check:
+    endpoint: "0.0.0.0:13133"
+
+receivers:
+  prometheus/ibmmq:
+    config:
+      scrape_configs:
+        - job_name: 'ibmmq'
+          scrape_interval: ${env:IBMMQ_SCRAPE_INTERVAL:-60s}
+          scrape_timeout: 15s
+          static_configs:
+            - targets:
+                - "${env:IBMMQ_EXPORTER_ENDPOINT:-localhost:9157}"
+          # For TLS/basic-auth, add scheme/tls_config/basic_auth under this job.
+
+processors:
+  # Detect host/cloud identity.
+  resourcedetection:
+    detectors: [env, ec2, gcp, azure, system]
+    system:
+      resource_attributes:
+        host.id:
+          enabled: true
+        host.name:
+          enabled: true
+
+  # Drop exporter self-metrics.
+  filter/ibmmq-overhead:
+    metrics:
+      exclude:
+        match_type: regexp
+        metric_names:
+          - "^go_.*"
+          - "^process_.*"
+          - "^promhttp_.*"
+          - "^scrape_.*"
+
+  # Drop high-cardinality SYSTEM.*/AMQ.* queues.
+  filter/ibmmq-queues:
+    metrics:
+      datapoint:
+        - 'attributes["queue"] != nil and IsMatch(attributes["queue"], "^SYSTEM[.](ADMIN[.]|MQSC[.]|DEFAULT[.]|AUTH[.]|CHANNEL[.]|CHLAUTH[.]|CICS[.]|SYNCPOINT[.]|INTERNAL[.]|PENDING[.]|PROTECTION[.]|BROKER[.]|AMQP[.]|DOTNET[.]|REST[.]|RETAINED[.]|SELECTION[.]|DURABLE[.]|HIERARCHY[.]|DDELAY[.])")'
+        - 'attributes["queue"] != nil and IsMatch(attributes["queue"], "^SYSTEM[.]CLUSTER[.](COMMAND|HISTORY)[.]QUEUE$")'
+        - 'attributes["queue"] != nil and IsMatch(attributes["queue"], "^AMQ[.]")'
+
+  # Tag host + cluster identity; drop collector-self attributes.
+  transform/ibmmq-cleanup:
+    metric_statements:
+      - context: resource
+        statements:
+          - set(attributes["target.name"], attributes["host.id"]) where attributes["host.id"] != nil
+          - set(attributes["cluster.name"], "${env:IBMMQ_CLUSTER_NAME:-}") where "${env:IBMMQ_CLUSTER_NAME:-}" != ""
+          - delete_key(attributes, "service.name")
+          - delete_key(attributes, "url.scheme")
+      - context: datapoint
+        statements:
+          - delete_key(attributes, "instance")
+          - delete_key(attributes, "job")
+
+  memory_limiter/ibmmq:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 256
+
+  # Prometheus counters are cumulative; New Relic ingest expects delta.
+  cumulativetodelta/ibmmq: {}
+
+  batch/ibmmq:
+    send_batch_size: 1000
+    timeout: 200ms
+
+exporters:
+  otlp/ibmmq:
+    endpoint: ${env:NEW_RELIC_OTLP_ENDPOINT:-https://otlp.nr-data.net:4317}
+    compression: gzip
+    headers:
+      api-key: ${env:NEW_RELIC_LICENSE_KEY}
+
+service:
+  extensions: [health_check]
+  pipelines:
+    metrics/ibmmq:
+      receivers: [prometheus/ibmmq]
+      processors: [memory_limiter/ibmmq, resourcedetection, filter/ibmmq-overhead, filter/ibmmq-queues, transform/ibmmq-cleanup, cumulativetodelta/ibmmq, batch/ibmmq]
+      exporters: [otlp/ibmmq]

--- a/infrastructure-monitoring/ibm-mq/otel-collector-config.yaml
+++ b/infrastructure-monitoring/ibm-mq/otel-collector-config.yaml
@@ -4,12 +4,8 @@
 # Env: NEW_RELIC_LICENSE_KEY (required); IBMMQ_EXPORTER_ENDPOINT (default localhost:9157);
 #      IBMMQ_CLUSTER_NAME (optional); NEW_RELIC_OTLP_ENDPOINT (default https://otlp.nr-data.net:4317).
 
-extensions:
-  health_check:
-    endpoint: "0.0.0.0:13133"
-
 receivers:
-  prometheus/ibmmq:
+  prometheus:
     config:
       scrape_configs:
         - job_name: 'ibmmq'
@@ -32,7 +28,7 @@ processors:
           enabled: true
 
   # Drop exporter self-metrics.
-  filter/ibmmq-overhead:
+  filter/overhead:
     metrics:
       exclude:
         match_type: regexp
@@ -43,7 +39,7 @@ processors:
           - "^scrape_.*"
 
   # Drop high-cardinality SYSTEM.*/AMQ.* queues.
-  filter/ibmmq-queues:
+  filter/queues:
     metrics:
       datapoint:
         - 'attributes["queue"] != nil and IsMatch(attributes["queue"], "^SYSTEM[.](ADMIN[.]|MQSC[.]|DEFAULT[.]|AUTH[.]|CHANNEL[.]|CHLAUTH[.]|CICS[.]|SYNCPOINT[.]|INTERNAL[.]|PENDING[.]|PROTECTION[.]|BROKER[.]|AMQP[.]|DOTNET[.]|REST[.]|RETAINED[.]|SELECTION[.]|DURABLE[.]|HIERARCHY[.]|DDELAY[.])")'
@@ -51,7 +47,7 @@ processors:
         - 'attributes["queue"] != nil and IsMatch(attributes["queue"], "^AMQ[.]")'
 
   # Tag host + cluster identity; drop collector-self attributes.
-  transform/ibmmq-cleanup:
+  transform:
     metric_statements:
       - context: resource
         statements:
@@ -64,29 +60,17 @@ processors:
           - delete_key(attributes, "instance")
           - delete_key(attributes, "job")
 
-  memory_limiter/ibmmq:
-    check_interval: 1s
-    limit_mib: 512
-    spike_limit_mib: 256
-
-  # Prometheus counters are cumulative; New Relic ingest expects delta.
-  cumulativetodelta/ibmmq: {}
-
-  batch/ibmmq:
-    send_batch_size: 1000
-    timeout: 200ms
+  batch: {}
 
 exporters:
-  otlp/ibmmq:
+  otlp:
     endpoint: ${env:NEW_RELIC_OTLP_ENDPOINT:-https://otlp.nr-data.net:4317}
-    compression: gzip
     headers:
       api-key: ${env:NEW_RELIC_LICENSE_KEY}
 
 service:
-  extensions: [health_check]
   pipelines:
-    metrics/ibmmq:
-      receivers: [prometheus/ibmmq]
-      processors: [memory_limiter/ibmmq, resourcedetection, filter/ibmmq-overhead, filter/ibmmq-queues, transform/ibmmq-cleanup, cumulativetodelta/ibmmq, batch/ibmmq]
-      exporters: [otlp/ibmmq]
+    metrics:
+      receivers: [prometheus]
+      processors: [resourcedetection, filter/overhead, filter/queues, transform, batch]
+      exporters: [otlp]

--- a/infrastructure-monitoring/ibm-mq/otel-collector-config.yaml
+++ b/infrastructure-monitoring/ibm-mq/otel-collector-config.yaml
@@ -46,12 +46,12 @@ processors:
         - 'attributes["queue"] != nil and IsMatch(attributes["queue"], "^SYSTEM[.]CLUSTER[.](COMMAND|HISTORY)[.]QUEUE$")'
         - 'attributes["queue"] != nil and IsMatch(attributes["queue"], "^AMQ[.]")'
 
-  # Tag host + cluster identity; drop collector-self attributes.
+  # Tag cluster identity; drop collector-self attributes.
+  # Host identity comes from resourcedetection (host.id / host.name) — no target.name needed.
   transform:
     metric_statements:
       - context: resource
         statements:
-          - set(attributes["target.name"], attributes["host.id"]) where attributes["host.id"] != nil
           - set(attributes["cluster.name"], "${env:IBMMQ_CLUSTER_NAME:-}") where "${env:IBMMQ_CLUSTER_NAME:-}" != ""
           - delete_key(attributes, "service.name")
           - delete_key(attributes, "url.scheme")


### PR DESCRIPTION
## Summary

Adds a self-contained IBM MQ monitoring example under `infrastructure-monitoring/ibm-mq`.

- `docker-compose.yaml` — IBM MQ, the **`mq-metric-samples` exporter built from source** (there is no published image), a small traffic generator, and the NRDOT collector.
- `mq_prometheus.yaml` — exporter config (`objects.queues`/`channels`, `useObjectStatus: true`) so it emits queue-manager + queue + channel metrics.
- `otel-collector-config.yaml` — scrapes the exporter and exports `ibmmq_*` to New Relic over **OTLP/gRPC** (`otlp` exporter, `https://otlp.nr-data.net:4317`). Resource detection (`env, ec2, gcp, azure, system`) maps `host.id` to the IBM MQ entity identity; the `qmgr`/`queue` labels are preserved for synthesis.
- `README.md` + `.env.example`; listed in the top-level README under "OpenTelemetry infrastructure monitoring".

Produces **both `IBMMQ_MANAGER` and `IBMMQ_QUEUE`** entities.

## Testing

Validated end-to-end on an EC2 host against a New Relic staging account: the exporter connects to the queue manager via PCF and serves `ibmmq_qmgr_*`/`queue_*`/`channel_*` on `:9157`, the collector scrapes and exports over gRPC, and both `IBMMQ_MANAGER` (QM1) and `IBMMQ_QUEUE` (`DEV.QUEUE.1/2/3`, DLQ) entities synthesize with `instrumentation.provider=opentelemetry`. Confirmed `ibmmq_*` datapoints arrive with `target.name` (host identity), `service.instance.id`, and `server.address` attributes intact.

## Note

The `mq-metric-samples` exporter has no published image, so the compose **builds it from the upstream repo** (pinned `v5.7.1`) on first `up` — it downloads the IBM MQ redistributable client, so the first build takes a few minutes. The `entity-definitions/.../infra-ibmmq_*` README links resolve once the entity-definitions PR merges.
